### PR TITLE
feat: bootstrap CMake-based builds

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,38 @@
+# Use the Google style in this project.
+BasedOnStyle: Google
+
+# Some folks prefer to write "int& foo" while others prefer "int &foo".  The
+# Google Style Guide only asks for consistency within a project, we chose
+# "int& foo" for this project:
+DerivePointerAlignment: false
+PointerAlignment: Left
+
+IncludeBlocks: Merge
+IncludeCategories:
+# Matches common headers first, but sorts them after project includes
+- Regex: '^\"google/cloud/functions/internal/'
+  Priority: 100
+- Regex: '^\"google/cloud/functions/'
+  Priority: 400
+- Regex: '^\"google/cloud/'  # project includes should sort first
+  Priority: 500
+- Regex: '^\"'
+  Priority: 1500
+- Regex: '^<grpc/'
+  Priority: 2000
+- Regex: '^<google/*'
+  Priority: 3000
+- Regex: '^<.*/.*'
+  Priority: 4000
+- Regex: '^<[^/]*>'
+  Priority: 5000
+
+# Format raw string literals with a `pb` or `proto` tag as proto.
+RawStringFormats:
+- Language: TextProto
+  Delimiters:
+  - 'pb'
+  - 'proto'
+  BasedOnStyle: Google
+
+CommentPragmas: '(@copydoc)'

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Common build output directory names
+.build/
+_build/
+
+# Used by some IDEs and LSP plugins
+compile_commands.json
+
+# Backup files for Emacs
+*~
+
+# Ignore IDEA / IntelliJ files
+.idea/
+cmake-build-*/
+
+# Ignore Visual Studio Code files
+.vsbuild/
+.vscode/
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,35 @@
+# ~~~
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+cmake_minimum_required(VERSION 3.10)
+
+set(PACKAGE_BUGREPORT "http://github.com/GoogleCloudPlatform/functions-framework-cpp")
+project(functions-framework-cpp CXX)
+
+set(FUNCTIONS_FRAMEWORK_CPP_VERSION_MAJOR 0)
+set(FUNCTIONS_FRAMEWORK_CPP_VERSION_MINOR 0)
+set(FUNCTIONS_FRAMEWORK_CPP_VERSION_PATCH 1)
+string(CONCAT FUNCTIONS_FRAMEWORK_CPP_VERSION "${FUNCTIONS_FRAMEWORK_CPP_VERSION_MAJOR}"
+        ".${FUNCTIONS_FRAMEWORK_CPP_VERSION_MINOR}"
+        ".${FUNCTIONS_FRAMEWORK_CPP_VERSION_PATCH}")
+
+# Configure the compiler options, we will be using C++17 features.
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
+
+add_subdirectory(google/cloud/functions)

--- a/cmake/BuildMetadata.cmake
+++ b/cmake/BuildMetadata.cmake
@@ -1,0 +1,66 @@
+# ~~~
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+# Define a function to fetch the current git revision. Using a function creates
+# a new scope, so the CMake variables do not leak to the global namespace.
+function (google_cloud_cpp_initialize_git_head var)
+    set(result "")
+    # If we cannot find a `.git` directory do not even try to guess the git
+    # revision.
+    if (IS_DIRECTORY ${PROJECT_SOURCE_DIR}/.git)
+        set(result "unknown-commit")
+        # We need `git` to find the revision.
+        find_program(GOOGLE_CLOUD_CPP_GIT_PROGRAM NAMES git)
+        mark_as_advanced(GOOGLE_CLOUD_CPP_GIT_PROGRAM)
+        if (GOOGLE_CLOUD_CPP_GIT_PROGRAM)
+            # Run `git rev-parse --short HEAD` and capture the output in a
+            # variable.
+            execute_process(
+                    COMMAND "${GOOGLE_CLOUD_CPP_GIT_PROGRAM}" rev-parse --short HEAD
+                    OUTPUT_VARIABLE GIT_HEAD_LOG
+                    ERROR_VARIABLE GIT_HEAD_LOG)
+            string(REPLACE "\n" "" result "${GIT_HEAD_LOG}")
+        endif ()
+    endif ()
+    set(${var}
+            "${result}"
+            PARENT_SCOPE)
+endfunction ()
+
+# Capture the compiler version and the git revision into variables, then
+# generate a config file with the values.
+if (NOT "${GOOGLE_CLOUD_CPP_BUILD_METADATA}" STREQUAL "")
+    # The build metadata flag is already defined, do not re-compute the
+    # initialization value. This works both when the user supplies
+    # -DGOOGLE_CLOUD_CPP_METADATA=value in the command line, and when
+    # GOOGLE_CLOUD_CPP_METADATA has a cached value
+    set(GOOGLE_CLOUD_CPP_GIT_HEAD "unused")
+else ()
+    google_cloud_cpp_initialize_git_head(GOOGLE_CLOUD_CPP_GIT_HEAD)
+endif ()
+
+# Define a CMake configuration option to set the build metadata. By default this
+# is initialized from `git rev-parse --short HEAD`, but the developer (or the
+# script building via CMake) can override the value.
+set(GOOGLE_CLOUD_CPP_BUILD_METADATA
+        "${GOOGLE_CLOUD_CPP_GIT_HEAD}"
+        CACHE STRING "Append build metadata to the library version number")
+# This option is rarely needed. Mark it as "advanced" to remove it from the
+# default CMake UIs.
+mark_as_advanced(GOOGLE_CLOUD_CPP_BUILD_METADATA)
+
+message(STATUS "google-cloud-cpp build metadata set to"
+        " ${GOOGLE_CLOUD_CPP_BUILD_METADATA}")

--- a/google/cloud/functions/CMakeLists.txt
+++ b/google/cloud/functions/CMakeLists.txt
@@ -1,0 +1,52 @@
+# ~~~
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+include(BuildMetadata)
+configure_file(internal/build_info.cc.in internal/build_info.cc)
+
+configure_file(internal/version_info.h.in
+        ${CMAKE_CURRENT_SOURCE_DIR}/internal/version_info.h)
+
+add_library(googleapis_functions_framework
+    # cmake-format: sort
+        ${CMAKE_CURRENT_BINARY_DIR}/internal/build_info.cc
+        internal/build_info.h
+        internal/compiler_info.cc
+        internal/compiler_info.h
+        internal/version_info.h
+        version.cc
+        version.h)
+target_include_directories(googleapis_functions_framework PUBLIC ${PROJECT_SOURCE_DIR})
+
+if (BUILD_TESTING)
+    find_package(GTest CONFIG REQUIRED)
+    set(googleapis_functions_framework_unit_tests
+            # cmake-format: sort
+            internal/compiler_info_test.cc
+            version_test.cc)
+
+    foreach (fname ${googleapis_functions_framework_unit_tests})
+        string(REPLACE "/" "_" target "${fname}")
+        string(REPLACE ".cc" "" target "${target}")
+        add_executable("${target}" ${fname})
+        target_link_libraries(
+                ${target}
+                PRIVATE googleapis_functions_framework
+                GTest::gmock_main GTest::gmock GTest::gtest)
+        add_test(NAME ${target} COMMAND ${target})
+    endforeach ()
+
+endif ()

--- a/google/cloud/functions/internal/build_info.cc.in
+++ b/google/cloud/functions/internal/build_info.cc.in
@@ -1,0 +1,41 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/functions/internal/build_info.h"
+#include "google/cloud/functions/internal/compiler_info.h"
+#include <algorithm>
+
+namespace google::cloud::functions_internal {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+
+std::string Compiler() {
+  return CompilerId() + " " + CompilerVersion();
+}
+
+std::string CompilerFlags() {
+  static char const kCompilerFlags[] =
+      R"""(@CMAKE_CXX_FLAGS@ ${CMAKE_CXX_FLAGS_${GOOGLE_CLOUD_CPP_BUILD_TYPE_UPPER}})""";
+  return kCompilerFlags;
+}
+
+std::string BuildMetadata() {
+  // Sometimes GOOGLE_CLOUD_CPP_BUILD_METADATA string expands to nothing, and
+  // then clang-tidy complains.
+  // NOLINTNEXTLINE(readability-redundant-string-init)
+  static char const kBuildMetadata[] = R"""(@GOOGLE_CLOUD_CPP_BUILD_METADATA@)""";
+  return kBuildMetadata;
+}
+
+}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+}  // namespace google::cloud::functions

--- a/google/cloud/functions/internal/build_info.h
+++ b/google/cloud/functions/internal/build_info.h
@@ -1,0 +1,35 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_BUILD_INFO_H
+#define FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_BUILD_INFO_H
+
+#include "google/cloud/functions/version.h"
+
+namespace google::cloud::functions_internal {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+
+/// The compiler version.
+std::string Compiler();
+
+/// The compiler flags.
+std::string CompilerFlags();
+
+/// Build metadata injected by the build system.
+std::string BuildMetadata();
+
+}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+}  // namespace google::cloud::functions
+
+#endif  // FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_BUILD_INFO_H

--- a/google/cloud/functions/internal/compiler_info.cc
+++ b/google/cloud/functions/internal/compiler_info.cc
@@ -1,0 +1,93 @@
+// Copyright 2020 Google LLC
+////
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/functions/internal/compiler_info.h"
+#include <sstream>
+
+namespace google::cloud::functions_internal {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+
+/**
+ * The macros for determining the compiler ID are taken from:
+ * https://gitlab.kitware.com/cmake/cmake/tree/v3.5.0/Modules/Compiler/\*-DetermineCompiler.cmake
+ * We do not care to detect every single compiler possible and only target the
+ * most popular ones.
+ *
+ * Order is significant as some compilers can define the same macros.
+ */
+std::string CompilerId() {
+#if defined(__apple_build_version__) && defined(__clang__)
+  return "AppleClang";
+#elif defined(__clang__)
+  return "Clang";
+#elif defined(__GNUC__)
+  return "GNU";
+#elif defined(_MSC_VER)
+  return "MSVC";
+#endif
+
+  return "Unknown";
+}
+
+std::string CompilerVersion() {
+  std::ostringstream os;
+
+#if defined(__apple_build_version__) && defined(__clang__)
+  os << __clang_major__ << "." << __clang_minor__ << "." << __clang_patchlevel__
+     << "." << __apple_build_version__;
+  return std::move(os).str();
+#elif defined(__clang__)
+  os << __clang_major__ << "." << __clang_minor__ << "."
+     << __clang_patchlevel__;
+  return std::move(os).str();
+#elif defined(__GNUC__)
+  os << __GNUC__ << "." << __GNUC_MINOR__ << "." << __GNUC_PATCHLEVEL__;
+  return std::move(os).str();
+#elif defined(_MSC_VER)
+  os << _MSC_VER / 100 << ".";
+  os << _MSC_VER % 100;
+#if defined(_MSC_FULL_VER)
+#if _MSC_VER >= 1400
+  os << "." << _MSC_FULL_VER % 100000;
+#else
+  os << "." << _MSC_FULL_VER % 10000;
+#endif
+#endif
+  return std::move(os).str();
+#endif
+
+  return "Unknown";
+}
+
+std::string LanguageVersion() {
+  auto constexpr kMagicVersionCxx98 = 199711L;
+  auto constexpr kMagicVersionCxx11 = 201103L;
+  auto constexpr kMagicVersionCxx14 = 201402L;
+  auto constexpr kMagicVersionCxx17 = 201703L;
+  switch (__cplusplus) {
+    case kMagicVersionCxx98:
+      return "1998";
+    case kMagicVersionCxx11:
+      return "2011";
+    case kMagicVersionCxx14:
+      return "2014";
+    case kMagicVersionCxx17:
+      return "2017";
+    default:
+      return "unknown";
+  }
+}
+
+}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+}  // namespace google::cloud::functions

--- a/google/cloud/functions/internal/compiler_info.h
+++ b/google/cloud/functions/internal/compiler_info.h
@@ -1,0 +1,45 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_COMPILER_INFO_H
+#define FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_COMPILER_INFO_H
+
+#include "google/cloud/functions/version.h"
+
+namespace google::cloud::functions_internal {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+/**
+ * Returns the compiler ID.
+ *
+ * The Compiler ID is a string like "GNU" or "Clang", as described by
+ * https://cmake.org/cmake/help/v3.5/variable/CMAKE_LANG_COMPILER_ID.html
+ */
+std::string CompilerId();
+
+/**
+ * Returns the compiler version.
+ *
+ * This string will be something like "9.1.1".
+ */
+std::string CompilerVersion();
+
+/**
+ * Returns the 4-digit year of the C++ language standard.
+ */
+std::string LanguageVersion();
+
+}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+}  // namespace google::cloud::functions
+
+#endif  // FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_COMPILER_INFO_H

--- a/google/cloud/functions/internal/compiler_info_test.cc
+++ b/google/cloud/functions/internal/compiler_info_test.cc
@@ -1,0 +1,47 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/functions/internal/compiler_info.h"
+#include <gmock/gmock.h>
+
+namespace google::cloud::functions_internal {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace {
+
+using ::testing::HasSubstr;
+
+TEST(CompilerInfo, CompilerId) {
+  auto const cn = CompilerId();
+  EXPECT_NE(cn, "");
+  EXPECT_EQ(std::string::npos,
+            cn.find_first_not_of(
+                "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"));
+}
+
+TEST(CompilerInfo, CompilerVersion) {
+  auto const cv = CompilerVersion();
+  EXPECT_NE(cv, "");
+  // Look for something that looks vaguely like an X.Y version number.
+  EXPECT_THAT(cv, ::testing::ContainsRegex(R"([0-9]+.[0-9]+)"));
+}
+
+TEST(CompilerInfo, LanguageVersion) {
+  auto const lv = LanguageVersion();
+  EXPECT_NE(lv, "");
+  EXPECT_EQ(std::string::npos, lv.find_first_not_of("0123456789"));
+}
+
+}  // namespace
+}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+}  // namespace google::cloud::functions_internal

--- a/google/cloud/functions/internal/version_info.h
+++ b/google/cloud/functions/internal/version_info.h
@@ -1,0 +1,22 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_INTERNAL_VERSION_INFO_H
+#define FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_INTERNAL_VERSION_INFO_H
+
+#define FUNCTIONS_FRAMEWORK_CPP_VERSION_MAJOR 0
+#define FUNCTIONS_FRAMEWORK_CPP_VERSION_MINOR 0
+#define FUNCTIONS_FRAMEWORK_CPP_VERSION_PATCH 1
+
+#endif  // FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_INTERNAL_VERSION_INFO_H

--- a/google/cloud/functions/internal/version_info.h.in
+++ b/google/cloud/functions/internal/version_info.h.in
@@ -1,0 +1,22 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_INTERNAL_VERSION_INFO_H
+#define FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_INTERNAL_VERSION_INFO_H
+
+#define FUNCTIONS_FRAMEWORK_CPP_VERSION_MAJOR @FUNCTIONS_FRAMEWORK_CPP_VERSION_MAJOR@
+#define FUNCTIONS_FRAMEWORK_CPP_VERSION_MINOR @FUNCTIONS_FRAMEWORK_CPP_VERSION_MINOR@
+#define FUNCTIONS_FRAMEWORK_CPP_VERSION_PATCH @FUNCTIONS_FRAMEWORK_CPP_VERSION_PATCH@
+
+#endif  // FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_INTERNAL_VERSION_INFO_H

--- a/google/cloud/functions/version.cc
+++ b/google/cloud/functions/version.cc
@@ -1,0 +1,37 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/functions/version.h"
+#include "google/cloud/functions/internal/build_info.h"
+#include <sstream>
+
+namespace google::cloud::functions {
+inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+
+std::string VersionString() {
+  static std::string const kVersion = [] {
+    std::ostringstream os;
+    os << "v" << VersionMajor() << "." << VersionMinor() << "."
+       << VersionPatch();
+    auto metadata = google::cloud::functions_internal::BuildMetadata();
+    if (!metadata.empty()) {
+      os << "+" << metadata;
+    }
+    return os.str();
+  }();
+  return kVersion;
+}
+
+}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+}  // namespace google::cloud::functions

--- a/google/cloud/functions/version.h
+++ b/google/cloud/functions/version.h
@@ -1,0 +1,64 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_VERSION_H
+#define FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_VERSION_H
+
+#include "google/cloud/functions/internal/version_info.h"
+#include <string>
+
+#define FUNCTIONS_FRAMEWORK_CPP_VCONCAT(Ma, Mi) v##Ma##_##Mi
+#define FUNCTIONS_FRAMEWORK_CPP_VEVAL(Ma, Mi) \
+  FUNCTIONS_FRAMEWORK_CPP_VCONCAT(Ma, Mi)
+#define FUNCTIONS_FRAMEWORK_CPP_NS                                     \
+  FUNCTIONS_FRAMEWORK_CPP_VEVAL(FUNCTIONS_FRAMEWORK_CPP_VERSION_MAJOR, \
+                                FUNCTIONS_FRAMEWORK_CPP_VERSION_MINOR)
+
+namespace google::cloud::functions {
+/**
+ * The C++ Functions Framework inlined, versioned namespace.
+ */
+inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+/// The C++ Functions Framework major version.
+int constexpr VersionMajor() { return FUNCTIONS_FRAMEWORK_CPP_VERSION_MAJOR; }
+
+/// The C++ Functions Framework minor version.
+int constexpr VersionMinor() { return FUNCTIONS_FRAMEWORK_CPP_VERSION_MINOR; }
+
+/// The C++ Functions Framework patch version.
+int constexpr VersionPatch() { return FUNCTIONS_FRAMEWORK_CPP_VERSION_PATCH; }
+
+namespace internal {
+auto constexpr kMaxMinorVersions = 100;
+auto constexpr kMaxPatchVersions = 100;
+}  // namespace internal
+
+/// A single integer representing the Major/Minor/Patch version.
+int constexpr Version() {
+  static_assert(VersionMinor() < internal::kMaxMinorVersions,
+                "version_minor() should be < kMaxMinorVersions");
+  static_assert(VersionPatch() < internal::kMaxPatchVersions,
+                "version_patch() should be < kMaxPatchVersions");
+  return internal::kMaxPatchVersions *
+             (internal::kMaxMinorVersions * VersionMajor() + VersionMinor()) +
+         VersionPatch();
+}
+
+/// The version as a string, in MAJOR.MINOR.PATCH+gitrev format.
+std::string VersionString();
+
+}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+}  // namespace google::cloud::functions
+
+#endif  // FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_VERSION_H

--- a/google/cloud/functions/version_test.cc
+++ b/google/cloud/functions/version_test.cc
@@ -1,0 +1,58 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/functions/version.h"
+#include "google/cloud/functions/internal/build_info.h"
+#include <gmock/gmock.h>
+#include <sstream>
+
+namespace google::cloud::functions {
+inline namespace GOOGLE_CLOUD_CPP_NS {
+namespace {
+
+using ::testing::HasSubstr;
+using ::testing::Not;
+using ::testing::StartsWith;
+
+/// @test A trivial test for the Google Cloud Storage C++ Client
+TEST(VersionTest, Simple) {
+  EXPECT_FALSE(VersionString().empty());
+  EXPECT_EQ(FUNCTIONS_FRAMEWORK_CPP_VERSION_MAJOR, VersionMajor());
+  EXPECT_EQ(FUNCTIONS_FRAMEWORK_CPP_VERSION_MINOR, VersionMinor());
+  EXPECT_EQ(FUNCTIONS_FRAMEWORK_CPP_VERSION_PATCH, VersionPatch());
+}
+
+/// @test Verify the version string starts with the version numbers.
+TEST(VersionTest, Format) {
+  std::ostringstream os;
+  os << "v" << FUNCTIONS_FRAMEWORK_CPP_VERSION_MAJOR << "."
+     << FUNCTIONS_FRAMEWORK_CPP_VERSION_MINOR << "."
+     << FUNCTIONS_FRAMEWORK_CPP_VERSION_PATCH;
+  EXPECT_THAT(VersionString(), StartsWith(os.str()));
+}
+
+/// @test Verify the version does not contain build info for release builds.
+TEST(VersionTest, NoBuildInfoInRelease) {
+  if (!google::cloud::functions_internal::BuildMetadata().empty()) {
+    EXPECT_THAT(
+        VersionString(),
+        HasSubstr("+" + google::cloud::functions_internal::BuildMetadata()));
+    return;
+  }
+  EXPECT_THAT(VersionString(), Not(HasSubstr("+")));
+}
+
+}  // namespace
+}  // namespace GOOGLE_CLOUD_CPP_NS
+}  // namespace google::cloud::functions


### PR DESCRIPTION
Create a library and some unit tests. I am not certain we will want to
have these functions (versions, compiler info, etc.) but they are easy
to copy from `google-cloud-cpp` and they provide something to bootstrap
the CI system around.