### PR TITLE
chore: added CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Code owners are automatically requested for review when someone opens a pull
+# request containing files matching the given path. The syntax for file paths
+# is the same as .gitignore.
+
+# The owners for all files in the repo, sorted alphabetically.
+* @coryan @devbww @devjgm @mr-salty @scotthart


### PR DESCRIPTION
This file contains the usernames of the code's owners. The file syntax
is similar to that of .gitignore. The owners will be automatically added
to the review line of PRs. This should make it easier for us to request
PR reviews, and it will definitely be easier for OSS contributors who
want to send a PR.

More info: https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners

NOTE: It did not work on this particular PR. I still needed to manually add reviewers to this PR. But it should work on the next PR.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googlecloudplatform/functions-framework-cpp/11)
<!-- Reviewable:end -->
