### PR TITLE
feat: implement command-line parsing function

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -10,6 +10,11 @@
 #  -readability-braces-around-statements: we think that often a one liner, such
 #      as `if (expr) return;` is more readable.
 #
+#  -google-runtime-references: this was based on a previous version of the
+#      Google Style Guide. References are encouraged and we think they better
+#      express the intent:
+#      https://google.github.io/styleguide/cppguide.html#Inputs_and_Outputs
+#
 #  -readability-redundant-declaration: A friend declaration inside a class
 #      counts as a declaration, so if we also declare that friend outside the
 #      class in order to document it as part of the public API, that will
@@ -45,6 +50,7 @@ Checks: >
   readability-*,
   -google-readability-namespace-comments,
   -google-readability-braces-around-statements,
+  -google-runtime-references,
   -readability-braces-around-statements,
   -readability-redundant-declaration,
   -modernize-use-trailing-return-type,

--- a/.github/workflows/sanitize.yaml
+++ b/.github/workflows/sanitize.yaml
@@ -22,7 +22,7 @@ jobs:
             ~/.cache/vcpkg
           key: ${{ runner.os }}-vcpkg
       - name: install-deps
-        run: vcpkg install gtest
+        run: vcpkg install gtest boost
       - name: configure with -fsanitize=${{matrix.sanitizer}}
         run: >
           cmake -S . -B ${{runner.workspace}}/build

--- a/google/cloud/functions/CMakeLists.txt
+++ b/google/cloud/functions/CMakeLists.txt
@@ -20,7 +20,7 @@ configure_file(internal/build_info.cc.in internal/build_info.cc)
 configure_file(internal/version_info.h.in
                ${CMAKE_CURRENT_SOURCE_DIR}/internal/version_info.h)
 
-find_package(Boost REQUIRED)
+find_package(Boost REQUIRED COMPONENTS program_options)
 
 add_library(
     googleapis_functions_framework # cmake-format: sort
@@ -32,6 +32,8 @@ add_library(
     internal/build_info.h
     internal/compiler_info.cc
     internal/compiler_info.h
+    internal/parse_options.cc
+    internal/parse_options.h
     internal/version_info.h
     internal/wrap_request.cc
     internal/wrap_request.h
@@ -42,7 +44,8 @@ add_library(
     version.h)
 target_include_directories(googleapis_functions_framework
                            PUBLIC ${PROJECT_SOURCE_DIR})
-target_link_libraries(googleapis_functions_framework PUBLIC Boost::headers)
+target_link_libraries(googleapis_functions_framework
+                      PUBLIC Boost::headers Boost::program_options)
 target_compile_definitions(googleapis_functions_framework
                            PUBLIC BOOST_BEAST_USE_STD_STRING_VIEW)
 
@@ -50,8 +53,11 @@ if (BUILD_TESTING)
     find_package(GTest CONFIG REQUIRED)
     set(googleapis_functions_framework_unit_tests
         # cmake-format: sort
-        http_response_test.cc internal/compiler_info_test.cc
-        internal/wrap_request_test.cc version_test.cc)
+        http_response_test.cc
+        internal/compiler_info_test.cc
+        internal/parse_options_test.cc
+        internal/wrap_request_test.cc
+        version_test.cc)
 
     foreach (fname ${googleapis_functions_framework_unit_tests})
         string(REPLACE "/" "_" target "${fname}")

--- a/google/cloud/functions/internal/parse_options.cc
+++ b/google/cloud/functions/internal/parse_options.cc
@@ -15,6 +15,8 @@
 #include "google/cloud/functions/internal/parse_options.h"
 #include <boost/program_options.hpp>
 #include <iostream>
+#include <limits>
+#include <stdexcept>
 
 namespace google::cloud::functions_internal {
 inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {

--- a/google/cloud/functions/internal/parse_options.cc
+++ b/google/cloud/functions/internal/parse_options.cc
@@ -1,0 +1,77 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/functions/internal/parse_options.h"
+#include <boost/program_options.hpp>
+#include <iostream>
+
+namespace google::cloud::functions_internal {
+inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+namespace po = boost::program_options;
+
+auto constexpr kDefaultPort = 8080;
+
+po::variables_map ParseOptions(int& argc, char const* const argv[]) {
+  // Validate a port value
+  auto validate_port = [](int value) {
+    if (value < std::numeric_limits<std::uint16_t>::min() ||
+        value > std::numeric_limits<std::uint16_t>::max()) {
+      std::ostringstream os;
+      os << "The PORT environment variable value (" << value
+         << ") is out of range.";
+      throw std::invalid_argument(std::move(os).str());
+    }
+  };
+  // Initialize the default port with the value from the "PORT" environment
+  // variable or with 8080.
+  auto port = [&]() -> std::uint16_t {
+    auto const* env = std::getenv("PORT");
+    if (env == nullptr) return kDefaultPort;
+    auto value = std::stoi(env);
+    validate_port(value);
+    return static_cast<std::uint16_t>(value);
+  }();
+
+  // Parse the command-line options.
+  po::options_description desc("Server configuration");
+  desc.add_options()
+      //
+      ("help", "produce help message")
+      //
+      ("address", po::value<std::string>()->default_value("0.0.0.0"),
+       "set listening address")
+      //
+      ("target", po::value<std::string>()->default_value(""),
+       "Ignored. This is required by the Functions Framework contract."
+       " See https://github.com/GoogleCloudPlatform/functions-framework for"
+       " additional information.")
+      //
+      ("signature-type", po::value<std::string>()->default_value(""),
+       "Ignored. This is required by the Functions Framework contract."
+       " See https://github.com/GoogleCloudPlatform/functions-framework for"
+       " additional information.")
+      //
+      ("port", po::value<int>()->default_value(port), "set listening port");
+  po::variables_map vm;
+  po::store(po::parse_command_line(argc, argv, desc), vm);
+  po::notify(vm);
+  if (vm.count("help") != 0) {
+    std::cout << desc << "\n";
+  }
+  validate_port(vm["port"].as<int>());
+  return vm;
+}
+
+}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+}  // namespace google::cloud::functions_internal

--- a/google/cloud/functions/internal/parse_options.h
+++ b/google/cloud/functions/internal/parse_options.h
@@ -22,7 +22,7 @@ namespace google::cloud::functions_internal {
 inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
 
 /// Parse the command-line options in @p argv
-boost::program_options::variables_map ParseOptions(int& argc,
+boost::program_options::variables_map ParseOptions(int argc,
                                                    char const* const argv[]);
 
 }  // namespace FUNCTIONS_FRAMEWORK_CPP_NS

--- a/google/cloud/functions/internal/parse_options.h
+++ b/google/cloud/functions/internal/parse_options.h
@@ -1,0 +1,31 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_INTERNAL_PARSE_OPTIONS_H
+#define FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_INTERNAL_PARSE_OPTIONS_H
+
+#include "google/cloud/functions/version.h"
+#include <boost/program_options/variables_map.hpp>
+
+namespace google::cloud::functions_internal {
+inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+
+/// Parse the command-line options in @p argv
+boost::program_options::variables_map ParseOptions(int& argc,
+                                                   char const* const argv[]);
+
+}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+}  // namespace google::cloud::functions_internal
+
+#endif  // FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_INTERNAL_PARSE_OPTIONS_H

--- a/google/cloud/functions/internal/parse_options_test.cc
+++ b/google/cloud/functions/internal/parse_options_test.cc
@@ -20,8 +20,6 @@ namespace google::cloud::functions_internal {
 inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
 namespace {
 
-using ::testing::HasSubstr;
-
 TEST(WrapRequestTest, Help) {
   char const* argv[] = {
       "unused",

--- a/google/cloud/functions/internal/parse_options_test.cc
+++ b/google/cloud/functions/internal/parse_options_test.cc
@@ -20,13 +20,21 @@ namespace google::cloud::functions_internal {
 inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
 namespace {
 
+TEST(WrapRequestTest, NoCmd) {
+  char const* argv[] = {};
+  auto const vm = ParseOptions(sizeof(argv) / sizeof(argv[0]), argv);
+  EXPECT_EQ(vm.count("help"), 0);
+}
+
+TEST(WrapRequestTest, NoArgs) {
+  char const* argv[] = {"unused"};
+  auto const vm = ParseOptions(sizeof(argv) / sizeof(argv[0]), argv);
+  EXPECT_EQ(vm.count("help"), 0);
+}
+
 TEST(WrapRequestTest, Help) {
-  char const* argv[] = {
-      "unused",
-      "--help",
-  };
-  int argc = sizeof(argv) / sizeof(argv[0]);
-  auto const vm = ParseOptions(argc, argv);
+  char const* argv[] = {"unused", "--help"};
+  auto const vm = ParseOptions(sizeof(argv) / sizeof(argv[0]), argv);
   EXPECT_NE(vm.count("help"), 0);
 }
 
@@ -45,8 +53,7 @@ TEST(WrapRequestTest, AcceptsRequiredOptions) {
       "unused",       "--port=8085",          "--address=localhost",
       "--target=foo", "--signature-type=bar",
   };
-  int argc = sizeof(argv) / sizeof(argv[0]);
-  auto const vm = ParseOptions(argc, argv);
+  auto const vm = ParseOptions(sizeof(argv) / sizeof(argv[0]), argv);
   EXPECT_EQ(vm.count("help"), 0);
   EXPECT_EQ(vm["port"].as<int>(), 8085);
   EXPECT_EQ(vm["address"].as<std::string>(), "localhost");
@@ -56,51 +63,35 @@ TEST(WrapRequestTest, AcceptsRequiredOptions) {
 
 TEST(WrapRequestTest, UseEnvForPort) {
   ::setenv("PORT", "8081", 1);
-  char const* argv[] = {
-      "unused",
-  };
-  int argc = sizeof(argv) / sizeof(argv[0]);
-  auto const vm = ParseOptions(argc, argv);
+  char const* argv[] = {"unused"};
+  auto const vm = ParseOptions(sizeof(argv) / sizeof(argv[0]), argv);
   EXPECT_EQ(vm["port"].as<int>(), 8081);
 }
 
 TEST(WrapRequestTest, CommandLineOverridesEnv) {
   ::setenv("PORT", "8081", 1);
-  char const* argv[] = {
-      "unused",
-      "--port=8082",
-  };
-  int argc = sizeof(argv) / sizeof(argv[0]);
-  auto const vm = ParseOptions(argc, argv);
+  char const* argv[] = {"unused", "--port=8082"};
+  auto const vm = ParseOptions(sizeof(argv) / sizeof(argv[0]), argv);
   EXPECT_EQ(vm["port"].as<int>(), 8082);
 }
 
 TEST(WrapRequestTest, PortEnvInvalid) {
   ::setenv("PORT", "not-a-number", 1);
-  char const* argv[] = {
-      "unused",
-      "--port=8080",
-  };
+  char const* argv[] = {"unused"};
   int argc = sizeof(argv) / sizeof(argv[0]);
   EXPECT_THROW(ParseOptions(argc, argv), std::exception);
 }
 
 TEST(WrapRequestTest, PortEnvTooLow) {
   ::setenv("PORT", "-1", 1);
-  char const* argv[] = {
-      "unused",
-      "--port=8080",
-  };
+  char const* argv[] = {"unused"};
   int argc = sizeof(argv) / sizeof(argv[0]);
   EXPECT_THROW(ParseOptions(argc, argv), std::exception);
 }
 
 TEST(WrapRequestTest, PortEnvTooHigh) {
   ::setenv("PORT", "65536", 1);
-  char const* argv[] = {
-      "unused",
-      "--port=8080",
-  };
+  char const* argv[] = {"unused"};
   int argc = sizeof(argv) / sizeof(argv[0]);
   EXPECT_THROW(ParseOptions(argc, argv), std::exception);
 }
@@ -111,12 +102,12 @@ TEST(WrapRequestTest, PortCommandLineInvalid) {
   char const* argv_2[] = {"unused", "--port=-1"};
   char const* argv_3[] = {"unused", "--port=65536"};
 
-  int argc = sizeof(argv_1) / sizeof(argv_1[0]);
-  EXPECT_THROW(ParseOptions(argc, argv_1), std::exception);
-  argc = sizeof(argv_2) / sizeof(argv_2[0]);
-  EXPECT_THROW(ParseOptions(argc, argv_2), std::exception);
-  argc = sizeof(argv_3) / sizeof(argv_3[0]);
-  EXPECT_THROW(ParseOptions(argc, argv_3), std::exception);
+  EXPECT_THROW(ParseOptions(sizeof(argv_1) / sizeof(argv_1[0]), argv_1),
+               std::exception);
+  EXPECT_THROW(ParseOptions(sizeof(argv_2) / sizeof(argv_2[0]), argv_2),
+               std::exception);
+  EXPECT_THROW(ParseOptions(sizeof(argv_3) / sizeof(argv_3[0]), argv_3),
+               std::exception);
 }
 
 }  // namespace

--- a/google/cloud/functions/internal/parse_options_test.cc
+++ b/google/cloud/functions/internal/parse_options_test.cc
@@ -1,0 +1,126 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/functions/internal/parse_options.h"
+#include <gmock/gmock.h>
+#include <cstdlib>
+
+namespace google::cloud::functions_internal {
+inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+namespace {
+
+using ::testing::HasSubstr;
+
+TEST(WrapRequestTest, Help) {
+  char const* argv[] = {
+      "unused",
+      "--help",
+  };
+  int argc = sizeof(argv) / sizeof(argv[0]);
+  auto const vm = ParseOptions(argc, argv);
+  EXPECT_NE(vm.count("help"), 0);
+}
+
+TEST(WrapRequestTest, ExceptionOnUnknown) {
+  char const* argv[] = {
+      "unused",
+      "--invalid-option-never-named-an-option-this",
+  };
+  int argc = sizeof(argv) / sizeof(argv[0]);
+  EXPECT_THROW(ParseOptions(argc, argv), std::exception);
+}
+
+TEST(WrapRequestTest, AcceptsRequiredOptions) {
+  ::unsetenv("PORT");
+  char const* argv[] = {
+      "unused",       "--port=8085",          "--address=localhost",
+      "--target=foo", "--signature-type=bar",
+  };
+  int argc = sizeof(argv) / sizeof(argv[0]);
+  auto const vm = ParseOptions(argc, argv);
+  EXPECT_EQ(vm.count("help"), 0);
+  EXPECT_EQ(vm["port"].as<int>(), 8085);
+  EXPECT_EQ(vm["address"].as<std::string>(), "localhost");
+  EXPECT_EQ(vm["target"].as<std::string>(), "foo");
+  EXPECT_EQ(vm["signature-type"].as<std::string>(), "bar");
+}
+
+TEST(WrapRequestTest, UseEnvForPort) {
+  ::setenv("PORT", "8081", 1);
+  char const* argv[] = {
+      "unused",
+  };
+  int argc = sizeof(argv) / sizeof(argv[0]);
+  auto const vm = ParseOptions(argc, argv);
+  EXPECT_EQ(vm["port"].as<int>(), 8081);
+}
+
+TEST(WrapRequestTest, CommandLineOverridesEnv) {
+  ::setenv("PORT", "8081", 1);
+  char const* argv[] = {
+      "unused",
+      "--port=8082",
+  };
+  int argc = sizeof(argv) / sizeof(argv[0]);
+  auto const vm = ParseOptions(argc, argv);
+  EXPECT_EQ(vm["port"].as<int>(), 8082);
+}
+
+TEST(WrapRequestTest, PortEnvInvalid) {
+  ::setenv("PORT", "not-a-number", 1);
+  char const* argv[] = {
+      "unused",
+      "--port=8080",
+  };
+  int argc = sizeof(argv) / sizeof(argv[0]);
+  EXPECT_THROW(ParseOptions(argc, argv), std::exception);
+}
+
+TEST(WrapRequestTest, PortEnvTooLow) {
+  ::setenv("PORT", "-1", 1);
+  char const* argv[] = {
+      "unused",
+      "--port=8080",
+  };
+  int argc = sizeof(argv) / sizeof(argv[0]);
+  EXPECT_THROW(ParseOptions(argc, argv), std::exception);
+}
+
+TEST(WrapRequestTest, PortEnvTooHigh) {
+  ::setenv("PORT", "65536", 1);
+  char const* argv[] = {
+      "unused",
+      "--port=8080",
+  };
+  int argc = sizeof(argv) / sizeof(argv[0]);
+  EXPECT_THROW(ParseOptions(argc, argv), std::exception);
+}
+
+TEST(WrapRequestTest, PortCommandLineInvalid) {
+  ::unsetenv("PORT");
+  char const* argv_1[] = {"unused", "--port=invalid-not-a-number"};
+  char const* argv_2[] = {"unused", "--port=-1"};
+  char const* argv_3[] = {"unused", "--port=65536"};
+
+  int argc = sizeof(argv_1) / sizeof(argv_1[0]);
+  EXPECT_THROW(ParseOptions(argc, argv_1), std::exception);
+  argc = sizeof(argv_2) / sizeof(argv_2[0]);
+  EXPECT_THROW(ParseOptions(argc, argv_2), std::exception);
+  argc = sizeof(argv_3) / sizeof(argv_3[0]);
+  EXPECT_THROW(ParseOptions(argc, argv_3), std::exception);
+}
+
+}  // namespace
+}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+}  // namespace google::cloud::functions_internal


### PR DESCRIPTION
Parses the command-line arguments for the framework, including any
environment variables. Supports the full Functions Framework contract,
but ignore the arguments that cannot be supported in C++ (not at
runtime), e.g., --target.

Fixes #24 