### PR TITLE
feat: wrap and unwrap Boost.Beast messages

### DIFF
--- a/google/cloud/functions/CMakeLists.txt
+++ b/google/cloud/functions/CMakeLists.txt
@@ -30,8 +30,11 @@ add_library(
     http_response.cc
     http_response.h
     internal/build_info.h
+    internal/call_user_function.cc
+    internal/call_user_function.h
     internal/compiler_info.cc
     internal/compiler_info.h
+    internal/http_message_types.h
     internal/parse_options.cc
     internal/parse_options.h
     internal/version_info.h
@@ -54,6 +57,7 @@ if (BUILD_TESTING)
     set(googleapis_functions_framework_unit_tests
         # cmake-format: sort
         http_response_test.cc
+        internal/call_user_function_test.cc
         internal/compiler_info_test.cc
         internal/parse_options_test.cc
         internal/wrap_request_test.cc

--- a/google/cloud/functions/http_response.h
+++ b/google/cloud/functions/http_response.h
@@ -21,6 +21,12 @@
 #include <string>
 #include <string_view>
 
+namespace google::cloud::functions_internal {
+inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+struct UnwrapResponse;
+}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+}  // namespace google::cloud::functions_internal
+
 namespace google::cloud::functions {
 inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
 
@@ -71,6 +77,7 @@ class HttpResponse {
   explicit HttpResponse(std::unique_ptr<Impl> impl) : impl_(std::move(impl)) {}
 
  private:
+  friend struct functions_internal::UnwrapResponse;
   std::shared_ptr<Impl> impl_;
 };
 

--- a/google/cloud/functions/internal/call_user_function.cc
+++ b/google/cloud/functions/internal/call_user_function.cc
@@ -1,0 +1,51 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/functions/internal/call_user_function.h"
+#include "google/cloud/functions/internal/wrap_request.h"
+#include "google/cloud/functions/internal/wrap_response.h"
+#include <iostream>
+#include <stdexcept>
+
+namespace google::cloud::functions_internal {
+inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+
+namespace be = ::boost::beast;
+
+struct UnwrapResponse {
+  static BeastResponse unwrap(functions::HttpResponse response) {
+    auto impl = std::move(response).impl_;
+    auto& wrap = dynamic_cast<WrapResponseImpl&>(*impl);
+    return std::move(wrap).response_;
+  }
+};
+
+BeastResponse CallUserFunction(UserFunction const& function,
+                               BeastRequest request) try {
+  auto response = function(MakeHttpRequest(std::move(request)));
+  return UnwrapResponse::unwrap(std::move(response));
+} catch (std::exception const& ex) {
+  std::cerr << "standard C++ exception thrown: " << ex.what() << std::endl;
+  BeastResponse response;
+  response.result(be::http::status::internal_server_error);
+  return response;
+} catch (...) {
+  std::cerr << "unknown c++ exception thrown" << std::endl;
+  BeastResponse response;
+  response.result(be::http::status::internal_server_error);
+  return response;
+}
+
+}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+}  // namespace google::cloud::functions_internal

--- a/google/cloud/functions/internal/call_user_function.h
+++ b/google/cloud/functions/internal/call_user_function.h
@@ -12,15 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/functions/internal/wrap_response.h"
+#ifndef FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_INTERNAL_CALL_USER_FUNCTION_H
+#define FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_INTERNAL_CALL_USER_FUNCTION_H
+
+#include "google/cloud/functions/internal/http_message_types.h"
+#include "google/cloud/functions/http_request.h"
+#include "google/cloud/functions/http_response.h"
+#include <functional>
 
 namespace google::cloud::functions_internal {
 inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
 
-/// Wrap a Boost.Beast request into a functions framework HTTP request.
-std::shared_ptr<functions::HttpResponse::Impl> MakeHttpResponse() {
-  return std::make_shared<WrapResponseImpl>();
-}
+using UserFunction =
+    std::function<functions::HttpResponse(functions::HttpRequest)>;
+
+BeastResponse CallUserFunction(UserFunction const& function,
+                               BeastRequest request);
 
 }  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
 }  // namespace google::cloud::functions_internal
+
+#endif  // FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_INTERNAL_CALL_USER_FUNCTION_H

--- a/google/cloud/functions/internal/call_user_function_test.cc
+++ b/google/cloud/functions/internal/call_user_function_test.cc
@@ -1,0 +1,73 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/functions/internal/call_user_function.h"
+#include <gmock/gmock.h>
+
+namespace google::cloud::functions_internal {
+inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+namespace {
+
+using ::testing::Contains;
+using ::testing::HasSubstr;
+namespace http = ::boost::beast::http;
+
+TEST(CallUserFunctionTest, Basic) {
+  auto func = [](functions::HttpRequest const& request) {
+    EXPECT_EQ(request.payload(), "Hello, is there anybody out there?");
+    EXPECT_EQ(request.verb(), "PUT");
+    EXPECT_EQ(request.target(), "/foo/bar");
+    EXPECT_THAT(request.headers(),
+                Contains(std::make_pair("x-goog-test", "test-value")));
+    functions::HttpResponse response{};
+    response.set_payload("just nod if you can hear me");
+    response.set_header("x-goog-test", "response-header");
+    return response;
+  };
+  BeastRequest request;
+  request.target("/foo/bar");
+  request.method(boost::beast::http::verb::put);
+  request.body() = "Hello, is there anybody out there?";
+  request.set("x-goog-test", "test-value");
+  auto response = CallUserFunction(func, std::move(request));
+  EXPECT_EQ(response.result_int(), 200);
+  EXPECT_EQ(response.body(), "just nod if you can hear me");
+  EXPECT_EQ(response["x-goog-test"], "response-header");
+}
+
+TEST(CallUserFunctionTest, ReturnError) {
+  auto constexpr kNotFound = 404;
+  auto func = [&](functions::HttpRequest const& /*request*/) {
+    functions::HttpResponse response{};
+    response.set_result(kNotFound);
+    return response;
+  };
+  BeastRequest request;
+  request.target("/foo/bar/not-there");
+  auto response = CallUserFunction(func, std::move(request));
+  EXPECT_EQ(response.result_int(), kNotFound);
+}
+
+TEST(CallUserFunctionTest, ReturnErrorOnException) {
+  auto func = [&](functions::HttpRequest const& /*request*/)
+      -> functions::HttpResponse { throw std::runtime_error("uh-oh"); };
+  BeastRequest request;
+  request.target("/foo/bar/bad");
+  auto response = CallUserFunction(func, std::move(request));
+  EXPECT_EQ(response.result(), http::status::internal_server_error);
+}
+
+}  // namespace
+}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+}  // namespace google::cloud::functions_internal

--- a/google/cloud/functions/internal/call_user_function_test.cc
+++ b/google/cloud/functions/internal/call_user_function_test.cc
@@ -58,12 +58,14 @@ TEST(CallUserFunctionTest, ReturnError) {
   EXPECT_EQ(response.result_int(), kNotFound);
 }
 
+functions::HttpResponse AlwaysThrow(functions::HttpRequest const& /*request*/) {
+  throw std::runtime_error("uh-oh");
+}
+
 TEST(CallUserFunctionTest, ReturnErrorOnException) {
-  auto func = [&](functions::HttpRequest const& /*request*/)
-      -> functions::HttpResponse { throw std::runtime_error("uh-oh"); };
   BeastRequest request;
   request.target("/foo/bar/bad");
-  auto response = CallUserFunction(func, std::move(request));
+  auto response = CallUserFunction(AlwaysThrow, std::move(request));
   EXPECT_EQ(response.result(), http::status::internal_server_error);
 }
 

--- a/google/cloud/functions/internal/call_user_function_test.cc
+++ b/google/cloud/functions/internal/call_user_function_test.cc
@@ -20,7 +20,6 @@ inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
 namespace {
 
 using ::testing::Contains;
-using ::testing::HasSubstr;
 namespace http = ::boost::beast::http;
 
 TEST(CallUserFunctionTest, Basic) {

--- a/google/cloud/functions/internal/http_message_types.h
+++ b/google/cloud/functions/internal/http_message_types.h
@@ -12,15 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/functions/internal/wrap_response.h"
+#ifndef FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_INTERNAL_HTTP_MESSAGE_TYPES_H
+#define FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_INTERNAL_HTTP_MESSAGE_TYPES_H
+
+#include "google/cloud/functions/version.h"
+#include <boost/beast/http.hpp>
 
 namespace google::cloud::functions_internal {
 inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
 
-/// Wrap a Boost.Beast request into a functions framework HTTP request.
-std::shared_ptr<functions::HttpResponse::Impl> MakeHttpResponse() {
-  return std::make_shared<WrapResponseImpl>();
-}
+using BeastRequest =
+    boost::beast::http::request<boost::beast::http::string_body>;
+
+using BeastResponse =
+    boost::beast::http::response<boost::beast::http::string_body>;
 
 }  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
 }  // namespace google::cloud::functions_internal
+
+#endif  // FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_INTERNAL_HTTP_MESSAGE_TYPES_H

--- a/google/cloud/functions/internal/wrap_request.h
+++ b/google/cloud/functions/internal/wrap_request.h
@@ -15,8 +15,8 @@
 #ifndef FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_INTERNAL_WRAP_REQUEST_H
 #define FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_INTERNAL_WRAP_REQUEST_H
 
-#include "google/cloud/functions/http_request.h"
 #include "google/cloud/functions/internal/http_message_types.h"
+#include "google/cloud/functions/http_request.h"
 #include "google/cloud/functions/version.h"
 
 namespace google::cloud::functions_internal {

--- a/google/cloud/functions/internal/wrap_request.h
+++ b/google/cloud/functions/internal/wrap_request.h
@@ -16,14 +16,11 @@
 #define FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_INTERNAL_WRAP_REQUEST_H
 
 #include "google/cloud/functions/http_request.h"
+#include "google/cloud/functions/internal/http_message_types.h"
 #include "google/cloud/functions/version.h"
-#include <boost/beast/http.hpp>
 
 namespace google::cloud::functions_internal {
 inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
-
-using BeastRequest =
-    boost::beast::http::request<boost::beast::http::string_body>;
 
 /// Wrap a Boost.Beast request into a functions framework HTTP request.
 ::google::cloud::functions::HttpRequest MakeHttpRequest(BeastRequest request);

--- a/google/cloud/functions/internal/wrap_response.h
+++ b/google/cloud/functions/internal/wrap_response.h
@@ -12,15 +12,60 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_INTERNAL_WRAP_REQUEST_H
-#define FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_INTERNAL_WRAP_REQUEST_H
+#ifndef FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_INTERNAL_WRAP_RESPONSE_H
+#define FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_INTERNAL_WRAP_RESPONSE_H
 
+#include "google/cloud/functions/internal/http_message_types.h"
 #include "google/cloud/functions/http_response.h"
 #include "google/cloud/functions/version.h"
-#include <boost/beast/http.hpp>
 
 namespace google::cloud::functions_internal {
 inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+
+struct UnwrapResponse;
+
+class WrapResponseImpl : public google::cloud::functions::HttpResponse::Impl {
+ public:
+  using Headers = google::cloud::functions::HttpResponse::HeadersType;
+
+  WrapResponseImpl() = default;
+  ~WrapResponseImpl() override = default;
+
+  void set_payload(std::string v) override { response_.body() = std::move(v); }
+  [[nodiscard]] std::string const& payload() const override {
+    return response_.body();
+  }
+  void set_result(int code) override { response_.result(code); }
+  [[nodiscard]] int result() const override {
+    return static_cast<int>(response_.result_int());
+  }
+
+  void set_header(std::string_view name, std::string_view value) override {
+    response_.set(name, value);
+  }
+  [[nodiscard]] Headers headers() const override {
+    Headers h;
+    for (auto const& f : response_) {
+      h.emplace(f.name_string(), f.value());
+    }
+    return h;
+  }
+
+  static inline auto constexpr kBeastHttpVersionFactor = 10;
+  void set_version(int major, int minor) override {
+    response_.version(major * kBeastHttpVersionFactor + minor);
+  }
+  [[nodiscard]] int version_major() const override {
+    return static_cast<int>(response_.version()) / kBeastHttpVersionFactor;
+  }
+  [[nodiscard]] int version_minor() const override {
+    return static_cast<int>(response_.version()) % kBeastHttpVersionFactor;
+  }
+
+ private:
+  friend struct UnwrapResponse;
+  BeastResponse response_;
+};
 
 /// Wrap a Boost.Beast request into a functions framework HTTP request.
 std::shared_ptr<functions::HttpResponse::Impl> MakeHttpResponse();
@@ -28,4 +73,4 @@ std::shared_ptr<functions::HttpResponse::Impl> MakeHttpResponse();
 }  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
 }  // namespace google::cloud::functions_internal
 
-#endif  // FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_INTERNAL_WRAP_REQUEST_H
+#endif  // FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_INTERNAL_WRAP_RESPONSE_H


### PR DESCRIPTION
We want to hide the Boost.Beast data types from the application, so we
need to call user-functions by wrapping the HTTP request and then
unwrapping the HTTP response.

Part of the work for #14 