### PR TITLE
ci: refactor builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,30 @@
+name: build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build-ubuntu-focal:
+    name: main build
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: cache-vcpkg
+      id: cache-vcpkg
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cache/vcpkg
+        key: ${{ runner.os }}-vcpkg-${{ hashFiles('vcpkg.json') }}
+    - name: configure
+      run: >
+        cmake -S . -B ${{runner.workspace}}/build
+        -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+        -DCMAKE_TOOLCHAIN_FILE=/usr/local/share/vcpkg/scripts/buildsystems/vcpkg.cmake
+    - name: build
+      run: cmake --build ${{runner.workspace}}/build
+    - name: test
+      working-directory: ${{runner.workspace}}/build
+      run: ctest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-ubuntu-focal:
-    name: main build
+    name: ubuntu-20.04
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,7 +17,7 @@ jobs:
       with:
         path: |
           ~/.cache/vcpkg
-        key: ${{ runner.os }}-vcpkg-${{ hashFiles('vcpkg.json') }}
+        key: vcpkg-${{ runner.os }}-${{ github.job }}-${{ hashFiles('vcpkg.json') }}
     - name: configure
       run: >
         cmake -S . -B ${{runner.workspace}}/build

--- a/.github/workflows/sanitize.yaml
+++ b/.github/workflows/sanitize.yaml
@@ -20,7 +20,7 @@ jobs:
         with:
           path: |
             ~/.cache/vcpkg
-          key: ${{ runner.os }}-vcpkg-${{ hashFiles('vcpkg.json') }}
+          key: vcpkg-${{ runner.os }}-${{ github.job }}-${{ matrix.sanitizer }}-${{ hashFiles('vcpkg.json') }}
       - name: -fsanitize=${{matrix.sanitizer}} / configure
         run: >
           cmake -S . -B ${{runner.workspace}}/build

--- a/.github/workflows/sanitize.yaml
+++ b/.github/workflows/sanitize.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   sanitized-build:
-    name: sanitize
+    name: ""
     runs-on: ubuntu-20.04
     strategy:
       matrix:

--- a/.github/workflows/sanitize.yaml
+++ b/.github/workflows/sanitize.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   sanitized-build:
-    name: ""
+    name: "/"
     runs-on: ubuntu-20.04
     strategy:
       matrix:

--- a/.github/workflows/sanitize.yaml
+++ b/.github/workflows/sanitize.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   sanitized-build:
-    name: Compile with multiple sanitizers
+    name: sanitize
     runs-on: ubuntu-20.04
     strategy:
       matrix:
@@ -21,7 +21,7 @@ jobs:
           path: |
             ~/.cache/vcpkg
           key: ${{ runner.os }}-vcpkg-${{ hashFiles('vcpkg.json') }}
-      - name: configure with -fsanitize=${{matrix.sanitizer}}
+      - name: -fsanitize=${{matrix.sanitizer}} / configure
         run: >
           cmake -S . -B ${{runner.workspace}}/build
           -DCMAKE_CXX_COMPILER=clang++-10
@@ -29,13 +29,13 @@ jobs:
           -DCMAKE_CXX_FLAGS=-fsanitize=${{matrix.sanitizer}}
           -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
           -DCMAKE_TOOLCHAIN_FILE=/usr/local/share/vcpkg/scripts/buildsystems/vcpkg.cmake
-      - name: build with -fsanitize=${{matrix.sanitizer}}
+      - name: -fsanitize=${{matrix.sanitizer}} / build
         run: cmake --build ${{runner.workspace}}/build
-      - name: test with -fsanitize=${{matrix.sanitizer}}
+      - name: -fsanitize=${{matrix.sanitizer}} / test
         working-directory: ${{runner.workspace}}/build
         env:
           ASAN_OPTIONS: detect_leaks=1:color=always
           LSAN_OPTIONS: report_objects=1
           TSAN_OPTIONS: halt_on_error=1:second_deadlock_stack=1
           UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1
-        run: ctest
+        run: ctest --output-on-failure

--- a/.github/workflows/sanitize.yaml
+++ b/.github/workflows/sanitize.yaml
@@ -7,7 +7,10 @@ on:
 
 jobs:
   sanitized-build:
-    name: "/"
+    # Using a blank name produces better output on
+    # the web UI (e.g. "sanitize /  (address)") than
+    # any other alternative we tried.
+    name: " "
     runs-on: ubuntu-20.04
     strategy:
       matrix:

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -1,4 +1,4 @@
-name: build-framework
+name: style
 
 on:
   push:
@@ -6,35 +6,30 @@ on:
   pull_request:
 
 jobs:
-  build-ubuntu:
-    name: Compile the Framework and Run Unit tests
+  clang-tidy:
+    name: main build
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
-    - name: cache-vcpkg
-      id: cache-vcpkg
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cache/vcpkg
-        key: ${{ runner.os }}-vcpkg-${{ hashFiles('vcpkg.json') }}
-    - name: configure
-      run: >
-        cmake -S . -B ${{runner.workspace}}/build
-        -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
-        -DCMAKE_TOOLCHAIN_FILE=/usr/local/share/vcpkg/scripts/buildsystems/vcpkg.cmake
-    - name: build
-      run: cmake --build ${{runner.workspace}}/build
-    - name: test
-      working-directory: ${{runner.workspace}}/build
-      run: ctest
-    - name: install clang-tidy
-      run: sudo apt install clang-tidy-10
-    - name: tidy
-      run: >
-        git ls-files -z |
-        grep -zE '\.cc$' |
-        xargs --verbose -P 2 -n 1 -0 clang-tidy-10 -p=${{runner.workspace}}/build
+      - uses: actions/checkout@v2
+      - name: cache-vcpkg
+        id: cache-vcpkg
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/vcpkg
+          key: ${{ runner.os }}-vcpkg-${{ hashFiles('vcpkg.json') }}
+      - name: configure
+        run: >
+          cmake -S . -B ${{runner.workspace}}/build
+          -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+          -DCMAKE_TOOLCHAIN_FILE=/usr/local/share/vcpkg/scripts/buildsystems/vcpkg.cmake
+      - name: install clang-tidy
+        run: sudo apt install clang-tidy-10
+      - name: tidy
+        run: >
+          git ls-files -z |
+          grep -zE '\.cc$' |
+          xargs --verbose -P 2 -n 1 -0 clang-tidy-10 -p=${{runner.workspace}}/build
 
   clang-format:
     name: Run clang-format over the code

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   clang-tidy:
-    name: main build
+    name: clang-tidy
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
@@ -17,7 +17,7 @@ jobs:
         with:
           path: |
             ~/.cache/vcpkg
-          key: ${{ runner.os }}-vcpkg-${{ hashFiles('vcpkg.json') }}
+          key: vcpkg-${{ runner.os }}-${{ github.job }}-${{ hashFiles('vcpkg.json') }}
       - name: configure
         run: >
           cmake -S . -B ${{runner.workspace}}/build
@@ -32,7 +32,7 @@ jobs:
           xargs --verbose -P 2 -n 1 -0 clang-tidy-10 -p=${{runner.workspace}}/build
 
   clang-format:
-    name: Run clang-format over the code
+    name: clang-format
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
@@ -42,7 +42,7 @@ jobs:
         run: git diff --ignore-submodules=all --color --exit-code .
 
   cmake-format:
-    name: Verify CMake files are properly formatted
+    name: cmake-format
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Rename the builds to make them easier to see in the UI. Split the
style-related jobs (clang-tidy, cmake-format, clang-format) to their own
workflow.