### PR TITLE
feat: initial version of the framework

### DIFF
--- a/google/cloud/functions/CMakeLists.txt
+++ b/google/cloud/functions/CMakeLists.txt
@@ -34,6 +34,8 @@ add_library(
     internal/call_user_function.h
     internal/compiler_info.cc
     internal/compiler_info.h
+    internal/framework.cc
+    internal/framework.h
     internal/http_message_types.h
     internal/parse_options.cc
     internal/parse_options.h
@@ -59,6 +61,7 @@ if (BUILD_TESTING)
         http_response_test.cc
         internal/call_user_function_test.cc
         internal/compiler_info_test.cc
+        internal/framework_test.cc
         internal/parse_options_test.cc
         internal/wrap_request_test.cc
         version_test.cc)

--- a/google/cloud/functions/internal/framework.cc
+++ b/google/cloud/functions/internal/framework.cc
@@ -1,0 +1,107 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/functions/internal/framework.h"
+#include "google/cloud/functions/internal/call_user_function.h"
+#include "google/cloud/functions/internal/parse_options.h"
+#include "google/cloud/functions/version.h"
+#include <boost/asio/ip/tcp.hpp>
+#include <boost/asio/strand.hpp>
+#include <boost/beast/core.hpp>
+#include <boost/beast/http.hpp>
+#include <boost/beast/version.hpp>
+#include <boost/program_options.hpp>
+#include <functional>
+#include <future>
+#include <iostream>
+#include <thread>
+
+namespace google::cloud::functions_internal {
+inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+namespace {
+namespace be = boost::beast;
+namespace asio = boost::asio;
+using tcp = boost::asio::ip::tcp;
+
+void HandleSession(tcp::socket socket, HttpFunction const& user_function) {
+  auto report_error = [](be::error_code ec, char const* what) {
+    // TODO(#35) - maybe replace with Boost.Log
+    std::cerr << what << ": " << ec.message() << "\n";
+  };
+  be::error_code ec;
+  for (;;) {
+    be::flat_buffer buffer;
+    // Read a request
+    BeastRequest request;
+    be::http::read(socket, buffer, request, ec);
+    if (ec == be::http::error::end_of_stream) break;
+    if (ec) return report_error(ec, "read");
+    auto const keep_alive = request.keep_alive();
+    auto response = CallUserFunction(user_function, std::move(request));
+    // TODO(#23) - maybe this is enough to declare success.
+    std::cout << std::flush;
+    std::cerr << std::flush;
+    // Send the response
+    response.set(be::http::field::server, BOOST_BEAST_VERSION_STRING);
+    response.prepare_payload();
+    response.keep_alive(keep_alive);
+    be::http::write(socket, response, ec);
+    if (ec) return report_error(ec, "write");
+  }
+  socket.shutdown(tcp::socket::shutdown_send, ec);
+};
+
+}  // namespace
+
+int RunForTest(int argc, char const* const argv[], HttpFunction handler,
+               std::function<bool()> const& shutdown,
+               std::function<void(int)> const& actual_port) {
+  auto vm = ParseOptions(argc, argv);
+  if (vm.count("help") != 0) return 0;
+
+  auto address = asio::ip::make_address(vm["address"].as<std::string>());
+  auto port = vm["port"].as<int>();
+
+  // TODO(#35) - maybe replace with Boost.Log
+  asio::io_context ioc{/*concurrency_hint=*/1};
+  tcp::acceptor acceptor{ioc, {address, static_cast<std::uint16_t>(port)}};
+  actual_port(acceptor.local_endpoint().port());
+
+  auto handle_session = [h = std::move(handler)](tcp::socket socket) {
+    HandleSession(std::move(socket), h);
+  };
+
+  while (!shutdown()) {
+    auto socket = acceptor.accept(ioc);
+    if (!socket.is_open()) break;
+    // Run a thread per-session, transferring ownership of the socket
+    (void)std::async(std::launch::async, handle_session, std::move(socket));
+  }
+  return 0;
+}
+
+int Run(int argc, char const* const argv[], HttpFunction handler) noexcept try {
+  return RunForTest(
+      argc, argv, std::move(handler), [] { return false; },
+      [](int /*unused*/) {});
+} catch (std::exception const& ex) {
+  std::cerr << "Standard C++ exception thrown " << ex.what() << "\n";
+  return 1;
+} catch (...) {
+  std::cerr << "Unknown exception thrown\n";
+  return 1;
+}
+
+}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+}  // namespace google::cloud::functions_internal

--- a/google/cloud/functions/internal/framework.h
+++ b/google/cloud/functions/internal/framework.h
@@ -44,7 +44,7 @@ using HttpFunction =
  *
  * HttpFunction FindHttpHandler() { return some_user_function; }
  *
- * int main(int argc, char* char* argv[]) {
+ * int main(int argc, char* argv[]) {
  *   return Run(argc, argv, FindHttpHandler());
  * }
  * @endcode

--- a/google/cloud/functions/internal/framework.h
+++ b/google/cloud/functions/internal/framework.h
@@ -1,0 +1,65 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_INTERNAL_FRAMEWORK_H
+#define FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_INTERNAL_FRAMEWORK_H
+
+#include "google/cloud/functions/http_request.h"
+#include "google/cloud/functions/http_response.h"
+#include "google/cloud/functions/version.h"
+#include <boost/program_options/variables_map.hpp>
+#include <functional>
+#include <thread>
+#include <vector>
+
+namespace google::cloud::functions_internal {
+inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+
+using HttpFunction =
+    std::function<functions::HttpResponse(functions::HttpRequest)>;
+
+/**
+ * Run the given function, invoking it to handle HTTP requests.
+ *
+ * Starts a HTTP server at the address and listening endpoint described by
+ * @p argv, invoking @p handler to handle any HTTP request. Note that we do not
+ * expect the application to use this function directly (it is in
+ * `functions_internal` after all), instead, our build scripts should create
+ * a `main()` function that calls this, as shown in the example:
+ *
+ * @par Example
+ * @code
+ * using ::google::cloud::functions::internal::Run;
+ *
+ * HttpFunction FindHttpHandler() { return some_user_function; }
+ *
+ * int main(int argc, char* char* argv[]) {
+ *   return Run(argc, argv, FindHttpHandler());
+ * }
+ * @endcode
+ *
+ * @see ParseOptions for more details of the command-line arguments used by this
+ *     function.
+ */
+int Run(int argc, char const* const argv[], HttpFunction handler) noexcept;
+
+/// Run the given function, returning after the first HTTP request.
+int RunForTest(int argc, char const* const argv[], HttpFunction handler,
+               std::function<bool()> const& shutdown,
+               std::function<void(int)> const& actual_port);
+
+}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+}  // namespace google::cloud::functions_internal
+
+#endif  // FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_INTERNAL_FRAMEWORK_H

--- a/google/cloud/functions/internal/framework_test.cc
+++ b/google/cloud/functions/internal/framework_test.cc
@@ -1,0 +1,84 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/functions/internal/framework.h"
+#include <boost/asio/connect.hpp>
+#include <boost/asio/ip/tcp.hpp>
+#include <boost/beast.hpp>
+#include <gmock/gmock.h>
+#include <cstdlib>
+#include <future>
+#include <iostream>
+#include <string>
+
+namespace google::cloud::functions_internal {
+inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+namespace {
+
+char const* const kTestArgv[] = {"unused", "--port=0"};
+auto constexpr kTestArgc = sizeof(kTestArgv) / sizeof(kTestArgv[0]);
+
+std::string HttpGet(std::string const& host, std::string const& port,
+                    std::string const& target) {
+  namespace beast = boost::beast;
+  namespace http = beast::http;
+  using tcp = boost::asio::ip::tcp;
+
+  // Create a socket to make the HTTP request over
+  boost::asio::io_context ioc;
+  tcp::resolver resolver(ioc);
+  beast::tcp_stream stream(ioc);
+  auto const results = resolver.resolve(host, port);
+  stream.connect(results);
+
+  // Use Boost.Beast to make the HTTP request
+  auto constexpr kHttpVersion = 10;  // 1.0 as Boost.Beast spells it
+  http::request<http::string_body> req{http::verb::get, target, kHttpVersion};
+  req.set(http::field::user_agent, BOOST_BEAST_VERSION_STRING);
+  req.set(http::field::host, host);
+  http::write(stream, req);
+  beast::flat_buffer buffer;
+  http::response<http::string_body> res;
+  http::read(stream, buffer, res);
+  stream.socket().shutdown(tcp::socket::shutdown_both);
+
+  // Return the body.
+  return std::move(res.body());
+}
+
+TEST(FrameworkTest, Basic) {
+  std::promise<int> port_p;
+  auto port_f = port_p.get_future();
+  std::atomic<bool> shutdown{false};
+  auto hello = [](functions::HttpRequest r) {
+    functions::HttpResponse response;
+    response.set_payload("Hello World from " + r.target());
+    response.set_header("content-type", "text/plain");
+    return response;
+  };
+  auto done = std::async(
+      std::launch::async, RunForTest, kTestArgc, kTestArgv, hello,
+      [&shutdown]() { return shutdown.load(); },
+      [&port_p](int port) mutable { port_p.set_value(port); });
+
+  auto port = port_f.get();
+  auto actual = HttpGet("localhost", std::to_string(port), "/say/hello");
+  EXPECT_EQ(actual, "Hello World from /say/hello");
+  shutdown.store(true);
+  EXPECT_EQ(done.get(), 0);
+}
+
+}  // namespace
+}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+}  // namespace google::cloud::functions_internal

--- a/google/cloud/functions/internal/framework_test.cc
+++ b/google/cloud/functions/internal/framework_test.cc
@@ -76,6 +76,12 @@ TEST(FrameworkTest, Basic) {
   auto actual = HttpGet("localhost", std::to_string(port), "/say/hello");
   EXPECT_EQ(actual, "Hello World from /say/hello");
   shutdown.store(true);
+  // Making a second request guarantees the change in `shutdown` is seen, but
+  // can fail.
+  try {
+    (void)HttpGet("localhost", std::to_string(port), "/quit/now");
+  } catch (...) {
+  }
   EXPECT_EQ(done.get(), 0);
 }
 

--- a/google/cloud/functions/internal/framework_test.cc
+++ b/google/cloud/functions/internal/framework_test.cc
@@ -17,9 +17,7 @@
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/beast.hpp>
 #include <gmock/gmock.h>
-#include <cstdlib>
 #include <future>
-#include <iostream>
 #include <string>
 
 namespace google::cloud::functions_internal {

--- a/google/cloud/functions/internal/framework_test.cc
+++ b/google/cloud/functions/internal/framework_test.cc
@@ -61,7 +61,7 @@ TEST(FrameworkTest, Basic) {
   std::promise<int> port_p;
   auto port_f = port_p.get_future();
   std::atomic<bool> shutdown{false};
-  auto hello = [](functions::HttpRequest r) {
+  auto hello = [](functions::HttpRequest const& r) {
     functions::HttpResponse response;
     response.set_payload("Hello World from " + r.target());
     response.set_header("content-type", "text/plain");


### PR DESCRIPTION
Add `google::cloud::functions::Run()`, a function to implement simple
HTTP servers.
