### PR TITLE
feat: implement development and runtime images

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -1,0 +1,47 @@
+name: images
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  images:
+    name: images
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: setup-buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: docker-cache
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: buildx-${{ runner.os }}-images-${{ github.sha }}
+          restore-keys: |
+            buildx-${{ runner.os }}-images-
+
+      - name: docker-build-runtime
+        uses: docker/build-push-action@v2
+        with:
+          push: false
+          load: true
+          tags: gcf-cpp-runtime
+          context: build_scripts
+          file: build_scripts/Dockerfile
+          target: gcf-cpp-runtime
+          cache-from: type=local,src=/tmp/.buildx-cache/runtime
+          cache-to: type=local,mode=max,dest=/tmp/.buildx-cache/runtime
+
+      - name: docker-build-develop
+        uses: docker/build-push-action@v2
+        with:
+          push: false
+          load: true
+          tags: gcf-cpp-develop
+          context: build_scripts
+          file: build_scripts/Dockerfile
+          target: gcf-cpp-incremental-8
+          cache-from: type=local,src=/tmp/.buildx-cache/develop
+          cache-to: type=local,mode=max,dest=/tmp/.buildx-cache/develop

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -42,6 +42,6 @@ jobs:
           tags: gcf-cpp-develop
           context: build_scripts
           file: build_scripts/Dockerfile
-          target: gcf-cpp-incremental-8
+          target: gcf-cpp-develop
           cache-from: type=local,src=/tmp/.buildx-cache/develop
           cache-to: type=local,mode=max,dest=/tmp/.buildx-cache/develop

--- a/build_scripts/Dockerfile
+++ b/build_scripts/Dockerfile
@@ -1,0 +1,104 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/gcp-runtimes/ubuntu_18_0_4 AS parent
+
+ARG cnb_uid=1000
+ARG cnb_gid=1000
+ARG stack_id="google"
+
+# Required by python/runtime.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  libexpat1 \
+  libffi6 \
+  libmpdec2 \
+  && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Required by dotnet/runtime.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  libicu60 \
+  && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Required by cpp/runtime.
+RUN apt-get update \
+    && apt-get install -y libc++1-9 \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+LABEL io.buildpacks.stack.id=${stack_id}
+RUN groupadd cnb --gid ${cnb_gid} && \
+  useradd --uid ${cnb_uid} --gid ${cnb_gid} -m -s /bin/bash cnb
+
+ENV CNB_USER_ID=${cnb_uid}
+ENV CNB_GROUP_ID=${cnb_gid}
+ENV CNB_STACK_ID=${stack_id}
+
+FROM parent AS gcf-cpp-runtime
+ENV PORT 8080
+USER cnb
+
+FROM parent AS gcf-cpp-incremental-0
+RUN apt-get update \
+    && apt install -y build-essential g++-8 gcc-8 git libstdc++-8-dev pkg-config ninja-build tar unzip zip \
+    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 100 \
+    && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 100 \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /layers/cpp
+RUN chown cnb /layers/cpp
+USER cnb
+
+RUN mkdir -p /layers/cpp/cmake /layers/cpp/vcpkg /layers/cpp/vcpkg-cache /layers/cpp/functions-framework-cpp
+
+RUN cd /layers/cpp/cmake && \
+    curl -sSL https://github.com/Kitware/CMake/releases/download/v3.18.4/cmake-3.18.4-Linux-x86_64.tar.gz | \
+    tar -xzf - --strip-components=1
+
+RUN cd /layers/cpp/vcpkg && \
+    curl -sSL https://github.com/Microsoft/vcpkg/archive/5dc53211caedebf4387d590155ed53ee44161f10.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    ./bootstrap-vcpkg.sh -disableMetrics
+
+ENV VCPKG_DEFAULT_BINARY_CACHE=/layers/cpp/vcpkg-cache
+
+# These are needed by the Functions Framework, do them one at a time, easier to
+# rebuild the Docker image if one of them fails to download or something.
+FROM gcf-cpp-incremental-0 AS gcf-cpp-incremental-1
+RUN /layers/cpp/vcpkg/vcpkg install --clean-after-build boost-core
+FROM gcf-cpp-incremental-1 AS gcf-cpp-incremental-2
+RUN /layers/cpp/vcpkg/vcpkg install --clean-after-build openssl
+FROM gcf-cpp-incremental-2 AS gcf-cpp-incremental-3
+RUN /layers/cpp/vcpkg/vcpkg install --clean-after-build boost-program-options
+FROM gcf-cpp-incremental-3 AS gcf-cpp-incremental-4
+RUN /layers/cpp/vcpkg/vcpkg install --clean-after-build boost-asio
+FROM gcf-cpp-incremental-4 AS gcf-cpp-incremental-5
+RUN /layers/cpp/vcpkg/vcpkg install --clean-after-build boost-beast
+
+# The following are not needed by the Functions Framework, but are used often
+# enough that it is a good idea to make them part of the base development
+# environment. Note that this automatically pulls abseil, grpc, protobuf, curl,
+# and a few other libraries.
+FROM gcf-cpp-incremental-5 AS gcf-cpp-incremental-6
+RUN /layers/cpp/vcpkg/vcpkg install --clean-after-build curl
+FROM gcf-cpp-incremental-6 AS gcf-cpp-incremental-7
+RUN /layers/cpp/vcpkg/vcpkg install --clean-after-build grpc
+FROM gcf-cpp-incremental-7 AS gcf-cpp-incremental-8
+RUN /layers/cpp/vcpkg/vcpkg install --clean-after-build google-cloud-cpp
+RUN echo "DISABLED: /layers/cpp/vcpkg/vcpkg install boost"
+
+FROM gcf-cpp-incremental-8 AS gcf-cpp-develop
+
+# TODO(#41) - switch to the actual vcpkg package once created.
+RUN mkdir -p /layers/cpp/gcf/cmake /layers/cpp/gcf/vcpkg-overlays
+COPY --chown=cnb vcpkg-overlays /layers/cpp/gcf/vcpkg-overlays
+RUN /layers/cpp/vcpkg/vcpkg install --clean-after-build \
+    --overlay-ports=/layers/cpp/gcf/vcpkg-overlays functions-framework-cpp

--- a/build_scripts/README.md
+++ b/build_scripts/README.md
@@ -1,0 +1,15 @@
+# Scripts to build Functions Framework-based applications
+
+This directory contains the scripts to
+
+1. Create a Docker image with all the development tools to build applications based on the functions
+   framework
+1. Create the runtime image to execute applications built with said image
+1. Support scripts to automatically create the code
+
+## Creating the Docker images
+
+```sh
+docker build -t gcf-cpp-runtime --target gcf-cpp-runtime - <Dockerfile
+docker build -t gcf-cpp-develop .
+```

--- a/build_scripts/vcpkg-overlays/portfile.cmake
+++ b/build_scripts/vcpkg-overlays/portfile.cmake
@@ -1,0 +1,27 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH
+    SOURCE_PATH
+    REPO
+    coryan/functions-framework-cpp
+    REF
+    d31250bce4ae9d9b6e3a99fe5e794c5ca515e728
+    SHA512
+    a90e3bcd5fa2d4c9eeaec58261de23a7da947fed87e9f0f73cc7378d09cbd3b43c1ce454bf69517b703c51e3af2c15cda0afe92c2ae4d0bac7c6d9749826ca19
+    HEAD_REF
+    main)
+
+vcpkg_configure_cmake(SOURCE_PATH ${SOURCE_PATH} PREFER_NINJA
+                      DISABLE_PARALLEL_CONFIGURE OPTIONS -DBUILD_TESTING=OFF)
+
+vcpkg_install_cmake(ADD_BIN_TO_PATH)
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake TARGET_PATH share)
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+file(
+    INSTALL ${SOURCE_PATH}/LICENSE
+    DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT}
+    RENAME copyright)
+
+vcpkg_copy_pdbs()

--- a/build_scripts/vcpkg-overlays/vcpkg.json
+++ b/build_scripts/vcpkg-overlays/vcpkg.json
@@ -1,0 +1,11 @@
+{
+  "name": "functions-framework-cpp",
+  "version-string": "0.0.1",
+  "port-version": 1,
+  "homepage": "https://github.com/GoogleCloudPlatform/functions-framework-cpp/",
+  "description": "Functions Framework for C++.",
+  "dependencies": [
+    "boost-program-options",
+    "boost-beast"
+  ]
+}


### PR DESCRIPTION
Add a `Dockerfile` and some support to generate development and runtime
images to build and deploy applications based on the framework. The
tests are very minimal at this point, we just check that the images can
be created, we do not verify that they are useful in any way. Additional
tests will come in future PRs. We also will need some scripts to use
these images, and some integration tests, but we need to start
somewhere.

Part of the work for #17 