### PR TITLE
ci: use previous cache when vcpkg.json changes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,6 +20,8 @@ jobs:
         path: |
           ~/.cache/vcpkg
         key: vcpkg-${{ runner.os }}-${{ github.job }}-${{ hashFiles('vcpkg.json') }}
+        restore-keys: |
+          vcpkg-${{ runner.os }}-${{ github.job }}-
     - name: configure
       run: >
         cmake -S . -B ${{runner.workspace}}/build -GNinja

--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -20,6 +20,8 @@ jobs:
           path: |
             ~/.cache/vcpkg
           key: vcpkg-${{ runner.os }}-${{ github.job }}-${{ hashFiles('vcpkg.json') }}
+          restore-keys: |
+            vcpkg-${{ runner.os }}-${{ github.job }}-
       - name: configure
         run: >
           cmake -S . -B ${{runner.workspace}}/build -GNinja -DBUILD_TESTING=OFF

--- a/.github/workflows/sanitize.yaml
+++ b/.github/workflows/sanitize.yaml
@@ -26,6 +26,8 @@ jobs:
           path: |
             ~/.cache/vcpkg
           key: vcpkg-${{ runner.os }}-${{ github.job }}-${{ matrix.sanitizer }}-${{ hashFiles('vcpkg.json') }}
+          restore-keys: |
+            vcpkg-${{ runner.os }}-${{ github.job }}-
       - name: -fsanitize=${{matrix.sanitizer}} / configure
         run: >
           cmake -S . -B ${{runner.workspace}}/build -GNinja

--- a/.github/workflows/sanitize.yaml
+++ b/.github/workflows/sanitize.yaml
@@ -27,7 +27,7 @@ jobs:
             ~/.cache/vcpkg
           key: vcpkg-${{ runner.os }}-${{ github.job }}-${{ matrix.sanitizer }}-${{ hashFiles('vcpkg.json') }}
           restore-keys: |
-            vcpkg-${{ runner.os }}-${{ github.job }}-
+            vcpkg-${{ runner.os }}-${{ github.job }}-${{ matrix.sanitizer }}-
       - name: -fsanitize=${{matrix.sanitizer}} / configure
         run: >
           cmake -S . -B ${{runner.workspace}}/build -GNinja

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -18,6 +18,8 @@ jobs:
           path: |
             ~/.cache/vcpkg
           key: vcpkg-${{ runner.os }}-${{ github.job }}-${{ hashFiles('vcpkg.json') }}
+          restore-keys: |
+            vcpkg-${{ runner.os }}-${{ github.job }}-
       - name: configure
         run: >
           cmake -S . -B ${{runner.workspace}}/build


### PR DESCRIPTION
TIL: a bit more about how GitHub Actions caching works. On a perfect
match for the hashing key the cache is not updated. When the inputs to
the cache change you certainly want to update it, but maybe you want to
reuse the previous version to start with a partially warm cache.  That
is what `restore-keys` is for. Warms up the cache, even if the inputs
change, and then update with the result.