### PR TITLE
feat: applications can provide their own CMake file

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -46,6 +46,15 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache/develop
           cache-to: type=local,mode=max,dest=/tmp/.buildx-cache/develop
 
+      - name: build-examples-hello-gcs
+        run: >
+          docker build
+          --pull=false
+          --build-arg=FUNCTION_SIGNATURE_TYPE=http
+          --build-arg=TARGET_FUNCTION=HelloGcs
+          -f build_scripts/build-application.Dockerfile
+          examples/hello_gcs
+
       - name: build-examples-hello-world
         run: >
           docker build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,3 +37,7 @@ list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
 include(CTest)
 add_subdirectory(google/cloud/functions)
+
+if (BUILD_TESTING)
+    add_subdirectory(examples)
+endif ()

--- a/build_scripts/build-application.Dockerfile
+++ b/build_scripts/build-application.Dockerfile
@@ -28,6 +28,6 @@ RUN /layers/cpp/cmake/bin/cmake -S /workspace -B /var/tmp/build -GNinja \
 RUN /layers/cpp/cmake/bin/cmake --build /var/tmp/build --target install
 
 FROM gcf-cpp-runtime AS runtime
-COPY --from=application /var/tmp/install/bin/application /r/application
+COPY --from=application /var/tmp/install/bin/function /r/application
 
 ENTRYPOINT ["/r/application"]

--- a/build_scripts/cmake/CMakeLists.txt
+++ b/build_scripts/cmake/CMakeLists.txt
@@ -23,9 +23,11 @@ function (functions_framework_cpp_define_target_with_glob directory)
     file(GLOB_RECURSE application_sources "${directory}/*.cc"
          "${directory}/*.cpp" "${directory}/*.cxx")
     add_library(functions_framework_cpp_function ${application_sources})
+    target_link_libraries(functions_framework_cpp_function
+                          PUBLIC googleapis-c++::functions_framework)
 endfunction ()
 
-if (EXISTS "application/CMakeLists.txt")
+if (EXISTS "${CMAKE_SOURCE_DIR}/application/CMakeLists.txt")
     add_subdirectory(application)
 else ()
     functions_framework_cpp_define_target_with_glob("application")
@@ -47,12 +49,9 @@ do include this file you must either:
             ]===])
 endif ()
 
-target_link_libraries(functions_framework_cpp_function
-                      PUBLIC googleapis-c++::functions_framework)
-
 add_executable(functions_framework_cpp_application main.cc)
 set_target_properties(functions_framework_cpp_application
-                      PROPERTIES OUTPUT_NAME application)
+                      PROPERTIES OUTPUT_NAME function)
 target_link_libraries(functions_framework_cpp_application
                       PRIVATE functions_framework_cpp_function)
 

--- a/build_scripts/cmake/CMakeLists.txt
+++ b/build_scripts/cmake/CMakeLists.txt
@@ -50,8 +50,8 @@ do include this file you must either:
 endif ()
 
 add_executable(functions_framework_cpp_application main.cc)
-set_target_properties(functions_framework_cpp_application
-                      PROPERTIES OUTPUT_NAME function)
+set_target_properties(functions_framework_cpp_application PROPERTIES OUTPUT_NAME
+                                                                     function)
 target_link_libraries(functions_framework_cpp_application
                       PRIVATE functions_framework_cpp_function)
 

--- a/build_scripts/vcpkg-overlays/portfile.cmake
+++ b/build_scripts/vcpkg-overlays/portfile.cmake
@@ -2,11 +2,11 @@ vcpkg_from_github(
     OUT_SOURCE_PATH
     SOURCE_PATH
     REPO
-    coryan/functions-framework-cpp
+    GoogleCloudPlatform/functions-framework-cpp
     REF
-    d31250bce4ae9d9b6e3a99fe5e794c5ca515e728
+    4a4a0a534b872b8ea09dd4f6f5d31afab9d02127
     SHA512
-    a90e3bcd5fa2d4c9eeaec58261de23a7da947fed87e9f0f73cc7378d09cbd3b43c1ce454bf69517b703c51e3af2c15cda0afe92c2ae4d0bac7c6d9749826ca19
+    eabb6f96912025ffca090ec8ec5cf7aaffc40bc3f327465dcaf9dd496f2157f32517055e48226917c23dcc0890ed2700dcf8c70822725dc198bca37bfe27dc14
     HEAD_REF
     main)
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -15,8 +15,13 @@
 # ~~~
 
 find_package(storage_client REQUIRED)
-find_package(googleapis_functions_framework)
 
-add_library(functions_framework_cpp_function hello_gcs.cc)
-target_link_libraries(functions_framework_cpp_function storage_client
-                      googleapis-c++::functions_framework)
+add_library(functions_framework_examples
+        # cmake-format: sort
+        hello_from_namespace/hello_from_namespace.cc
+        hello_from_nested_namespace/hello_from_nested_namespace.cc
+        hello_world/hello_world.cc
+        hello_gcs/hello_gcs.cc)
+target_link_libraries(functions_framework_examples
+        storage_client
+        googleapis-c++::functions_framework)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -16,12 +16,10 @@
 
 find_package(storage_client REQUIRED)
 
-add_library(functions_framework_examples
-        # cmake-format: sort
-        hello_from_namespace/hello_from_namespace.cc
-        hello_from_nested_namespace/hello_from_nested_namespace.cc
-        hello_world/hello_world.cc
-        hello_gcs/hello_gcs.cc)
-target_link_libraries(functions_framework_examples
-        storage_client
-        googleapis-c++::functions_framework)
+add_library(
+    functions_framework_examples # cmake-format: sort
+    hello_from_namespace/hello_from_namespace.cc
+    hello_from_nested_namespace/hello_from_nested_namespace.cc
+    hello_gcs/hello_gcs.cc hello_world/hello_world.cc)
+target_link_libraries(functions_framework_examples storage_client
+                      googleapis-c++::functions_framework)

--- a/examples/hello_gcs/CMakeLists.txt
+++ b/examples/hello_gcs/CMakeLists.txt
@@ -1,0 +1,24 @@
+# ~~~
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+find_package(storage_client REQUIRED)
+find_package(googleapis_functions_framework)
+
+message("DEBUG DEBUG DEBUG")
+
+add_library(functions_framework_cpp_function hello_gcs.cc)
+target_link_libraries(functions_framework_cpp_function storage_client
+                      googleapis-c++::functions_framework)

--- a/examples/hello_gcs/hello_gcs.cc
+++ b/examples/hello_gcs/hello_gcs.cc
@@ -1,0 +1,44 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <google/cloud/functions/internal/framework.h>
+#include <google/cloud/storage/client.h>
+#include <sstream>
+
+using ::google::cloud::functions::HttpRequest;
+using ::google::cloud::functions::HttpResponse;
+namespace gcs = ::google::cloud::storage;
+
+HttpResponse HelloGcs(HttpRequest request) {  // NOLINT
+  std::vector<std::string> components;
+  std::istringstream split(request.target());
+  for (std::string c; std::getline(split, c, '/'); components.push_back(c))
+    ;
+  if (components.size() != 2) {
+    HttpResponse response;
+    response.set_result(400);
+    return response;
+  }
+  auto const bucket = components[0];
+  auto const object = components[1];
+  auto client = gcs::Client::CreateDefaultClient().value();
+  auto reader = client.ReadObject(bucket, object);
+  std::string contents(std::istreambuf_iterator<char>{reader},
+                     std::istreambuf_iterator<char>{});
+
+  HttpResponse response;
+  response.set_header("Content-Type", "application/octet-stream");
+  response.set_payload(std::move(contents));
+  return response;
+}

--- a/examples/hello_gcs/hello_gcs.cc
+++ b/examples/hello_gcs/hello_gcs.cc
@@ -30,8 +30,8 @@ HttpResponse HelloGcs(HttpRequest request) {  // NOLINT
 
   std::vector<std::string> components;
   std::istringstream split(request.target());
-  for (std::string c; std::getline(split, c, '/'); components.push_back(c))
-    ;
+  for (std::string c; std::getline(split, c, '/'); components.push_back(c)) {
+  }
 
   if (components.size() != 2) return error();
   auto const bucket = components[0];

--- a/examples/hello_gcs/hello_gcs.cc
+++ b/examples/hello_gcs/hello_gcs.cc
@@ -35,7 +35,7 @@ HttpResponse HelloGcs(HttpRequest request) {  // NOLINT
   auto client = gcs::Client::CreateDefaultClient().value();
   auto reader = client.ReadObject(bucket, object);
   std::string contents(std::istreambuf_iterator<char>{reader},
-                     std::istreambuf_iterator<char>{});
+                       std::istreambuf_iterator<char>{});
 
   HttpResponse response;
   response.set_header("Content-Type", "application/octet-stream");

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -6,6 +6,7 @@
   "description": "Functions Framework for C++ -- Development",
   "dependencies": [
     "boost",
+    "google-cloud-cpp",
     "gtest"
   ]
 }


### PR DESCRIPTION
Fix the code to support applications that provide their own CMake file
for the code. This is needed for more complex functions that depend on
additional libraries or even third-party dependencies. Wrote an example
to showcase this use-case and updated the builds to compile this
example.

Fixes #21 