### PR TITLE
ci: add build to test shared libraries

### DIFF
--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -41,3 +41,29 @@ jobs:
           -DCMAKE_TOOLCHAIN_FILE=/usr/local/share/vcpkg/scripts/buildsystems/vcpkg.cmake
       - name: test-build
         run: cmake --build ${{runner.workspace}}/build-quickstart
+
+  build-ubuntu-focal-shared:
+    name: ubuntu-20.04-shared
+    runs-on: ubuntu-20.04
+    steps:
+      - name: install-dependencies
+        run: sudo apt install ninja-build libboost-dev libboost-program-options-dev
+      - uses: actions/checkout@v2
+      - name: configure
+        run: >
+          cmake -S . -B ${{runner.workspace}}/build -GNinja
+          -DBUILD_TESTING=OFF -DBUILD_SHARED_LIBS=ON
+          -DCMAKE_INSTALL_PREFIX=${{runner.temp}}/staging
+          -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+      - name: build
+        run: cmake --build ${{runner.workspace}}/build
+      - name: install
+        working-directory: ${{runner.workspace}}/build
+        run: cmake --build ${{runner.workspace}}/build --target install
+      - name: test-configure
+        run: >
+          cmake -S google/cloud/functions/quickstart -B ${{runner.workspace}}/build-quickstart -GNinja
+          -DCMAKE_PREFIX_PATH=${{runner.temp}}/staging
+          -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+      - name: test-build
+        run: cmake --build ${{runner.workspace}}/build-quickstart

--- a/google/cloud/functions/quickstart/vcpkg.json
+++ b/google/cloud/functions/quickstart/vcpkg.json
@@ -6,7 +6,6 @@
   "description": "Functions Framework for C++.",
   "dependencies": [
     "boost-beast",
-    "boost-program-options",
-    "gtest"
+    "boost-program-options"
   ]
 }


### PR DESCRIPTION
Compiles the framework and quickstart using BUILD_SHARED_LIBS=ON.

Fixes #19 