### PR TITLE
feat: intercept special targets

### DIFF
--- a/google/cloud/functions/integration_tests/basic_integration_test.cc
+++ b/google/cloud/functions/integration_tests/basic_integration_test.cc
@@ -100,6 +100,12 @@ TEST(RunIntegrationTest, Basic) {
   actual = HttpGet("localhost", "8080", "/exception/");
   EXPECT_THAT(actual.result_int(), kInternalError);
 
+  actual = HttpGet("localhost", "8080", "/favicon.ico");
+  EXPECT_THAT(actual.result_int(), kNotFound);
+
+  actual = HttpGet("localhost", "8080", "/robots.txt");
+  EXPECT_THAT(actual.result_int(), kNotFound);
+
   try {
     (void)HttpGet("localhost", "8080", "/quit/program/0");
   } catch (...) {

--- a/google/cloud/functions/internal/call_user_function.cc
+++ b/google/cloud/functions/internal/call_user_function.cc
@@ -33,6 +33,11 @@ struct UnwrapResponse {
 
 BeastResponse CallUserFunction(UserFunction const& function,
                                BeastRequest request) try {
+  if (request.target() == "/favicon.ico" || request.target() == "/robots.txt") {
+    BeastResponse response;
+    response.result(be::http::status::not_found);
+    return response;
+  }
   auto response = function(MakeHttpRequest(std::move(request)));
   return UnwrapResponse::unwrap(std::move(response));
 } catch (std::exception const& ex) {

--- a/google/cloud/functions/internal/call_user_function_test.cc
+++ b/google/cloud/functions/internal/call_user_function_test.cc
@@ -69,6 +69,20 @@ TEST(CallUserFunctionTest, ReturnErrorOnException) {
   EXPECT_EQ(response.result(), http::status::internal_server_error);
 }
 
+TEST(CallUserFunctionTest, InterceptRobotsTxt) {
+  BeastRequest request;
+  request.target("/robots.txt");
+  auto response = CallUserFunction(AlwaysThrow, std::move(request));
+  EXPECT_EQ(response.result(), http::status::not_found);
+}
+
+TEST(CallUserFunctionTest, InterceptFaviconIco) {
+  BeastRequest request;
+  request.target("/favicon.ico");
+  auto response = CallUserFunction(AlwaysThrow, std::move(request));
+  EXPECT_EQ(response.result(), http::status::not_found);
+}
+
 }  // namespace
 }  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
 }  // namespace google::cloud::functions_internal


### PR DESCRIPTION
The spec requires that `/favicon.ico` and `/robots.txt` be intercepted
by the framework. The application function should not be called, and 404
is returned instead.

Fixes #26 