### PR TITLE
feat: parse CloudEvent from JSON

### DIFF
--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: install-dependencies
-        run: sudo apt install ninja-build libboost-dev libboost-program-options-dev
+        run: sudo apt install ninja-build libboost-dev libboost-program-options-dev nlohmann-json3-dev
       - name: install-abseil
         run: >
           curl -sSL https://github.com/abseil/abseil-cpp/archive/20200225.2.tar.gz |

--- a/build_scripts/vcpkg-overlays/vcpkg.json
+++ b/build_scripts/vcpkg-overlays/vcpkg.json
@@ -7,6 +7,8 @@
   "dependencies": [
     "abseil",
     "boost-beast",
-    "boost-program-options"
+    "boost-program-options",
+    "boost-serialization",
+    "nlohmann-json"
   ]
 }

--- a/google/cloud/functions/CMakeLists.txt
+++ b/google/cloud/functions/CMakeLists.txt
@@ -41,6 +41,8 @@ add_library(
     internal/framework.cc
     internal/framework.h
     internal/http_message_types.h
+    internal/parse_cloud_event_json.cc
+    internal/parse_cloud_event_json.h
     internal/parse_options.cc
     internal/parse_options.h
     internal/version_info.h
@@ -75,6 +77,7 @@ if (BUILD_TESTING)
         internal/call_user_function_test.cc
         internal/compiler_info_test.cc
         internal/framework_test.cc
+        internal/parse_cloud_event_json_test.cc
         internal/parse_options_test.cc
         internal/wrap_request_test.cc
         version_test.cc)

--- a/google/cloud/functions/internal/parse_cloud_event_json.cc
+++ b/google/cloud/functions/internal/parse_cloud_event_json.cc
@@ -1,0 +1,79 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/functions/internal/parse_cloud_event_json.h"
+#include <boost/archive/iterators/binary_from_base64.hpp>
+#include <boost/archive/iterators/transform_width.hpp>
+#include <nlohmann/json.hpp>
+
+namespace google::cloud::functions_internal {
+inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+
+/// Parse @p json_string as a Cloud Event
+functions::CloudEvent ParseCloudEventJson(std::string_view json_string) {
+  auto json = nlohmann::json::parse(json_string);
+
+  auto event = functions::CloudEvent(
+      json.at("id").get<std::string>(), json.at("source").get<std::string>(),
+      json.at("type").get<std::string>(),
+      json.value("specversion", functions::CloudEvent::kDefaultSpecVersion));
+
+  if (json.count("datacontenttype") != 0) {
+    event.set_data_content_type(json.at("datacontenttype").get<std::string>());
+  }
+  if (json.count("dataschema") != 0) {
+    event.set_data_schema(json.at("dataschema").get<std::string>());
+  }
+  if (json.count("subject") != 0) {
+    event.set_subject(json.at("subject").get<std::string>());
+  }
+  if (json.count("time") != 0) {
+    event.set_time(json.at("time").get<std::string>());
+  }
+  if (json.count("data") != 0) {
+    auto d = json.at("data");
+    if (d.is_object()) {
+      event.set_data(d.dump());
+    } else {
+      event.set_data(d.get<std::string>());
+    }
+  } else if (json.count("data_base64") != 0) {
+    auto base64 = json.at("data_base64").get<std::string>();
+    namespace bai = boost::archive::iterators;
+    auto constexpr kBase64RawBits = 6;
+    auto constexpr kBase64EncodedBits = 8;
+    using Decoder =
+        bai::transform_width<bai::binary_from_base64<std::string::iterator>,
+                             kBase64EncodedBits, kBase64RawBits>;
+    // Pad the raw string if needed.
+    base64.append((4 - base64.size() % 4) % 4, '=');
+    auto const last_non_pad = base64.find_last_not_of('=');
+    auto const pad_count =
+        std::distance(base64.begin() + last_non_pad + 1, base64.end());
+    std::string data{Decoder(base64.begin()), Decoder(base64.end())};
+    if (pad_count == 2) {
+      data.pop_back();
+      data.pop_back();
+    } else if (pad_count == 1) {
+      data.pop_back();
+    }
+    // TODO(#117) - consider storing as std::vector<std::uint8_t>
+    event.set_data(std::move(data));
+  }
+
+  return event;
+}
+
+}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+}  // namespace google::cloud::functions_internal

--- a/google/cloud/functions/internal/parse_cloud_event_json.h
+++ b/google/cloud/functions/internal/parse_cloud_event_json.h
@@ -1,0 +1,31 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_INTERNAL_PARSE_CLOUD_EVENT_JSON_H
+#define FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_INTERNAL_PARSE_CLOUD_EVENT_JSON_H
+
+#include "google/cloud/functions/version.h"
+#include "google/cloud/functions/cloud_event.h"
+#include <string_view>
+
+namespace google::cloud::functions_internal {
+inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+
+/// Parse @p json_string as a Cloud Event
+functions::CloudEvent ParseCloudEventJson(std::string_view json_string);
+
+}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+}  // namespace google::cloud::functions_internal
+
+#endif  // FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_INTERNAL_PARSE_CLOUD_EVENT_JSON_H

--- a/google/cloud/functions/internal/parse_cloud_event_json.h
+++ b/google/cloud/functions/internal/parse_cloud_event_json.h
@@ -15,8 +15,8 @@
 #ifndef FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_INTERNAL_PARSE_CLOUD_EVENT_JSON_H
 #define FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_INTERNAL_PARSE_CLOUD_EVENT_JSON_H
 
-#include "google/cloud/functions/version.h"
 #include "google/cloud/functions/cloud_event.h"
+#include "google/cloud/functions/version.h"
 #include <string_view>
 
 namespace google::cloud::functions_internal {

--- a/google/cloud/functions/internal/parse_cloud_event_json_test.cc
+++ b/google/cloud/functions/internal/parse_cloud_event_json_test.cc
@@ -1,0 +1,224 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/functions/internal/parse_cloud_event_json.h"
+#include <gmock/gmock.h>
+
+namespace google::cloud::functions_internal {
+inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+namespace {
+
+TEST(ParseCloudEventJson, Basic) {
+  auto constexpr kText = R"js({
+    "type" : "com.example.someevent",
+    "source" : "/mycontext",
+    "id" : "A234-1234-1234"})js";
+  auto ce = ParseCloudEventJson(kText);
+  EXPECT_EQ(ce.id(), "A234-1234-1234");
+  EXPECT_EQ(ce.source(), "/mycontext");
+  EXPECT_EQ(ce.type(), "com.example.someevent");
+  EXPECT_EQ(ce.spec_version(), functions::CloudEvent::kDefaultSpecVersion);
+
+  EXPECT_THROW(ParseCloudEventJson("{"), std::exception);
+}
+
+TEST(ParseCloudEventJson, WithSpecVersion) {
+  auto constexpr kText = R"js({
+    "type" : "com.example.someevent",
+    "source" : "/mycontext",
+    "id" : "A234-1234-1234",
+    "specversion" : "1.1"})js";
+  auto ce = ParseCloudEventJson(kText);
+  EXPECT_EQ(ce.id(), "A234-1234-1234");
+  EXPECT_EQ(ce.source(), "/mycontext");
+  EXPECT_EQ(ce.type(), "com.example.someevent");
+  EXPECT_EQ(ce.spec_version(), "1.1");
+}
+
+TEST(ParseCloudEventJson, MissingRequiredField) {
+  auto constexpr kMissingId = R"js({
+    "type" : "com.example.someevent",
+    "source" : "/mycontext"})js";
+  auto constexpr kMissingType = R"js({
+    "source" : "/mycontext",
+    "id" : "A234-1234-1234"})js";
+  auto constexpr kMissingSource = R"js({
+    "type" : "com.example.someevent",
+    "id" : "A234-1234-1234"})js";
+  EXPECT_THROW(ParseCloudEventJson(kMissingId), std::exception);
+  EXPECT_THROW(ParseCloudEventJson(kMissingType), std::exception);
+  EXPECT_THROW(ParseCloudEventJson(kMissingSource), std::exception);
+}
+
+TEST(ParseCloudEventJson, InvalidRequiredField) {
+  auto constexpr kInvalidId = R"js({
+    "type" : "com.example.someevent",
+    "source" : "/mycontext",
+    "id" : [ "A234-1234-1234" ]})js";
+  auto constexpr kInvalidType = R"js({
+    "type" : [ "com.example.someevent" ],
+    "source" : "/mycontext",
+    "id" : "A234-1234-1234"})js";
+  auto constexpr kInvalidSource = R"js({
+    "type" : "com.example.someevent",
+    "source" : [ "/mycontext" ],
+    "id" : "A234-1234-1234"})js";
+  EXPECT_THROW(ParseCloudEventJson(kInvalidId), std::exception);
+  EXPECT_THROW(ParseCloudEventJson(kInvalidType), std::exception);
+  EXPECT_THROW(ParseCloudEventJson(kInvalidSource), std::exception);
+}
+
+TEST(ParseCloudEventJson, WithDataContentType) {
+  auto constexpr kText = R"js({
+    "type" : "com.example.someevent",
+    "source" : "/mycontext",
+    "id" : "A234-1234-1234",
+    "datacontenttype" : "application/json"})js";
+  auto constexpr kTextInvalid = R"js({
+    "type" : "com.example.someevent",
+    "source" : "/mycontext",
+    "id" : "A234-1234-1234",
+    "datacontenttype" : {"foo": "bar"}})js";
+  auto const ce = ParseCloudEventJson(kText);
+  EXPECT_THAT(ce.data_content_type().value_or(""), "application/json");
+  EXPECT_THROW(ParseCloudEventJson(kTextInvalid), std::exception);
+}
+
+TEST(ParseCloudEventJson, WithDataSchema) {
+  auto constexpr kText = R"js({
+    "type" : "com.example.someevent",
+    "source" : "/mycontext",
+    "id" : "A234-1234-1234",
+    "dataschema" : "test-schema"})js";
+  auto constexpr kTextInvalid = R"js({
+    "type" : "com.example.someevent",
+    "source" : "/mycontext",
+    "id" : "A234-1234-1234",
+    "dataschema" : {"foo": "bar"}})js";
+  auto const ce = ParseCloudEventJson(kText);
+  EXPECT_THAT(ce.data_schema().value_or(""), "test-schema");
+  EXPECT_THROW(ParseCloudEventJson(kTextInvalid), std::exception);
+}
+
+TEST(ParseCloudEventJson, WithSubject) {
+  auto constexpr kText = R"js({
+    "type" : "com.example.someevent",
+    "source" : "/mycontext",
+    "id" : "A234-1234-1234",
+    "subject" : "test-subject"})js";
+  auto constexpr kTextInvalid = R"js({
+    "type" : "com.example.someevent",
+    "source" : "/mycontext",
+    "id" : "A234-1234-1234",
+    "subject" : {"foo": "bar"}})js";
+  auto const ce = ParseCloudEventJson(kText);
+  EXPECT_THAT(ce.subject().value_or(""), "test-subject");
+  EXPECT_THROW(ParseCloudEventJson(kTextInvalid), std::exception);
+}
+
+TEST(ParseCloudEventJson, WithTime) {
+  auto constexpr kText = R"js({
+    "type" : "com.example.someevent",
+    "source" : "/mycontext",
+    "id" : "A234-1234-1234",
+    "time" : "2018-04-05T17:31:05Z"})js";
+  auto constexpr kTextInvalid = R"js({
+    "type" : "com.example.someevent",
+    "source" : "/mycontext",
+    "id" : "A234-1234-1234",
+    "time" : {"foo": "bar"}})js";
+  // obtained using: date -u --date='2018-04-05T17:31:05Z' +%s
+  auto constexpr kExpectedTime = std::chrono::seconds(1522949465L);
+  auto const ce = ParseCloudEventJson(kText);
+  auto tp = ce.time().value_or(std::chrono::system_clock::from_time_t(0));
+  // This assumes the platform uses a unix epoch, reasonably safe assumption for
+  // our needs.
+  EXPECT_EQ(tp, std::chrono::system_clock::from_time_t(kExpectedTime.count()));
+  EXPECT_THROW(ParseCloudEventJson(kTextInvalid), std::exception);
+}
+
+TEST(ParseCloudEventJson, WithData) {
+  auto constexpr kText = R"js({
+    "type" : "com.example.someevent",
+    "source" : "/mycontext",
+    "id" : "A234-1234-1234",
+    "data" : "some text"})js";
+  auto constexpr kTextInvalid = R"js({
+    "type" : "com.example.someevent",
+    "source" : "/mycontext",
+    "id" : "A234-1234-1234",
+    "dataschema" : {"foo": "bar"}})js";
+  auto const ce = ParseCloudEventJson(kText);
+  EXPECT_EQ(ce.data().value_or(""), "some text");
+  EXPECT_THROW(ParseCloudEventJson(kTextInvalid), std::exception);
+}
+
+TEST(ParseCloudEventJson, WithDataBase64) {
+  // Obtained magic string using:
+  //   echo "some text" | openssl base64 -e
+  auto constexpr kText = R"js({
+    "type" : "com.example.someevent",
+    "source" : "/mycontext",
+    "id" : "A234-1234-1234",
+    "data_base64" : "c29tZSB0ZXh0Cg=="})js";
+  auto constexpr kTextInvalid = R"js({
+    "type" : "com.example.someevent",
+    "source" : "/mycontext",
+    "id" : "A234-1234-1234",
+    "dataschema" : {"foo": "bar"}})js";
+  auto const ce = ParseCloudEventJson(kText);
+  EXPECT_EQ(ce.data().value_or(""), "some text\n");
+  EXPECT_THROW(ParseCloudEventJson(kTextInvalid), std::exception);
+}
+
+TEST(ParseCloudEventJson, WithDataBase64Padding) {
+  // Obtained magic string using:
+  //   echo -n "" | openssl base64 -e
+  //   echo -n "a" | openssl base64 -e
+  //   echo -n "ab" | openssl base64 -e
+  //   echo -n "abc" | openssl base64 -e
+  struct Test {
+    std::string expected_data;
+    std::string json;
+  } cases[] = {
+      {"", R"js({
+    "type" : "com.example.someevent",
+    "source" : "/mycontext",
+    "id" : "A234-1234-1234",
+    "data_base64" : ""})js"},
+      {"a", R"js({
+    "type" : "com.example.someevent",
+    "source" : "/mycontext",
+    "id" : "A234-1234-1234",
+    "data_base64" : "YQ=="})js"},
+      {"ab", R"js({
+    "type" : "com.example.someevent",
+    "source" : "/mycontext",
+    "id" : "A234-1234-1234",
+    "data_base64" : "YWI="})js"},
+      {"abc", R"js({
+    "type" : "com.example.someevent",
+    "source" : "/mycontext",
+    "id" : "A234-1234-1234",
+    "data_base64" : "YWJj"})js"},
+  };
+  for (auto const& c : cases) {
+    auto const ce = ParseCloudEventJson(c.json);
+    EXPECT_EQ(ce.data().value_or(""), c.expected_data);
+  }
+}
+
+}  // namespace
+}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+}  // namespace google::cloud::functions_internal

--- a/google/cloud/functions/quickstart/vcpkg.json
+++ b/google/cloud/functions/quickstart/vcpkg.json
@@ -7,6 +7,8 @@
   "dependencies": [
     "abseil",
     "boost-beast",
-    "boost-program-options"
+    "boost-program-options",
+    "boost-serialization",
+    "nlohmann-json"
   ]
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -10,8 +10,10 @@
     "boost-filesystem",
     "boost-process",
     "boost-program-options",
+    "boost-serialization",
     "fmt",
     "google-cloud-cpp",
-    "gtest"
+    "gtest",
+    "nlohmann-json"
   ]
 }


### PR DESCRIPTION
Add function to parse a stringified JSON object into a
`functions::CloudEvent`.

Fixes #120 