### PR TITLE
feat: implement Run() for Cloud Event handlers

### DIFF
--- a/google/cloud/functions/CMakeLists.txt
+++ b/google/cloud/functions/CMakeLists.txt
@@ -47,6 +47,7 @@ add_library(
     internal/parse_cloud_event_json.h
     internal/parse_options.cc
     internal/parse_options.h
+    internal/user_functions.h
     internal/version_info.h
     internal/wrap_request.cc
     internal/wrap_request.h

--- a/google/cloud/functions/internal/framework.cc
+++ b/google/cloud/functions/internal/framework.cc
@@ -63,7 +63,7 @@ void HandleSession(tcp::socket socket, UserFunction const& user_function) {
     if (ec) return report_error(ec, "write");
   }
   socket.shutdown(tcp::socket::shutdown_send, ec);
-};
+}
 
 template <typename UserFunction>
 int RunForTestImpl(int argc, char const* const argv[], UserFunction&& function,
@@ -118,17 +118,17 @@ int Run(int argc, char const* const argv[],
   return RunImpl(argc, argv, std::move(handler));
 }
 
-int RunForTest(int argc, char const* const argv[], UserHttpFunction function,
+int RunForTest(int argc, char const* const argv[], UserHttpFunction handler,
                std::function<bool()> const& shutdown,
                std::function<void(int)> const& actual_port) {
-  return RunForTestImpl(argc, argv, std::move(function), shutdown, actual_port);
+  return RunForTestImpl(argc, argv, std::move(handler), shutdown, actual_port);
 }
 
 int RunForTest(int argc, char const* const argv[],
-               UserCloudEventFunction function,
+               UserCloudEventFunction handler,
                std::function<bool()> const& shutdown,
                std::function<void(int)> const& actual_port) {
-  return RunForTestImpl(argc, argv, std::move(function), shutdown, actual_port);
+  return RunForTestImpl(argc, argv, std::move(handler), shutdown, actual_port);
 }
 
 }  // namespace FUNCTIONS_FRAMEWORK_CPP_NS

--- a/google/cloud/functions/internal/framework.h
+++ b/google/cloud/functions/internal/framework.h
@@ -75,10 +75,10 @@ int Run(int argc, char const* const argv[], UserHttpFunction handler) noexcept;
  * https://github.com/cloudevents/spec/blob/v1.0/http-protocol-binding.md
  */
 int Run(int argc, char const* const argv[],
-        UserCloudEventFunction function) noexcept;
+        UserCloudEventFunction handler) noexcept;
 
 /// Implement functions::Run(), with additional helpers for testing.
-int RunForTest(int argc, char const* const argv[], UserHttpFunction function,
+int RunForTest(int argc, char const* const argv[], UserHttpFunction handler,
                std::function<bool()> const& shutdown,
                std::function<void(int)> const& actual_port);
 

--- a/google/cloud/functions/internal/framework.h
+++ b/google/cloud/functions/internal/framework.h
@@ -34,11 +34,12 @@ inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
  * @par Example
  * @code
  * using ::google::cloud::functions_internal::Run;
+ * namespace gcf = ::google::cloud::functions;
  *
- * HttpFunction FindHttpHandler() { return some_user_function; }
+ * extern gcf::HttpResponse MyHandler(gcf::HttpRequest);
  *
  * int main(int argc, char* argv[]) {
- *   return Run(argc, argv, FindHttpHandler());
+ *   return Run(argc, argv, MyHandler);
  * }
  * @endcode
  *
@@ -60,11 +61,12 @@ int Run(int argc, char const* const argv[], UserHttpFunction handler) noexcept;
  * @par Example
  * @code
  * using ::google::cloud::functions_internal::Run;
+ * namespace gcf = ::google::cloud::functions;
  *
- * CloudEventFunction FindCloudEventHandler() { return some_user_function; }
+ * extern void MyHandler(gcf::CloudEvent);
  *
  * int main(int argc, char* argv[]) {
- *   return Run(argc, argv, FindHttpHandler());
+ *   return Run(argc, argv, MyHandler);
  * }
  * @endcode
  *

--- a/google/cloud/functions/internal/framework.h
+++ b/google/cloud/functions/internal/framework.h
@@ -15,16 +15,12 @@
 #ifndef FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_INTERNAL_FRAMEWORK_H
 #define FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_INTERNAL_FRAMEWORK_H
 
-#include "google/cloud/functions/http_request.h"
-#include "google/cloud/functions/http_response.h"
+#include "google/cloud/functions/internal/user_functions.h"
 #include "google/cloud/functions/version.h"
 #include <functional>
 
 namespace google::cloud::functions_internal {
 inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
-
-using HttpFunction =
-    std::function<functions::HttpResponse(functions::HttpRequest)>;
 
 /**
  * Run the given function, invoking it to handle HTTP requests.
@@ -37,7 +33,7 @@ using HttpFunction =
  *
  * @par Example
  * @code
- * using ::google::cloud::functions::internal::Run;
+ * using ::google::cloud::functions_internal::Run;
  *
  * HttpFunction FindHttpHandler() { return some_user_function; }
  *
@@ -49,10 +45,46 @@ using HttpFunction =
  * @see ParseOptions for more details of the command-line arguments used by this
  *     function.
  */
-int Run(int argc, char const* const argv[], HttpFunction handler) noexcept;
+int Run(int argc, char const* const argv[], UserHttpFunction handler) noexcept;
+
+/**
+ * Run the given function, invoking it to handle Cloud Events.
+ *
+ * Starts a HTTP server at the address and listening endpoint described by
+ * @p argv, invoking @p handler to handle any HTTP request which *MUST* conform
+ * to the Cloud Events [HTTP protocol binding][cloud-events-spec]. Note that we
+ * do not expect the application to use this function directly (it is in
+ * `functions_internal` after all), instead, our build scripts should create a
+ * `main()` function that calls this, as shown in the example:
+ *
+ * @par Example
+ * @code
+ * using ::google::cloud::functions_internal::Run;
+ *
+ * CloudEventFunction FindCloudEventHandler() { return some_user_function; }
+ *
+ * int main(int argc, char* argv[]) {
+ *   return Run(argc, argv, FindHttpHandler());
+ * }
+ * @endcode
+ *
+ * @see ParseOptions for more details of the command-line arguments used by this
+ *     function.
+ *
+ * [cloud-events-spec]:
+ * https://github.com/cloudevents/spec/blob/v1.0/http-protocol-binding.md
+ */
+int Run(int argc, char const* const argv[],
+        UserCloudEventFunction function) noexcept;
 
 /// Implement functions::Run(), with additional helpers for testing.
-int RunForTest(int argc, char const* const argv[], HttpFunction handler,
+int RunForTest(int argc, char const* const argv[], UserHttpFunction function,
+               std::function<bool()> const& shutdown,
+               std::function<void(int)> const& actual_port);
+
+/// Implement functions::Run(), with additional helpers for testing.
+int RunForTest(int argc, char const* const argv[],
+               UserCloudEventFunction handler,
                std::function<bool()> const& shutdown,
                std::function<void(int)> const& actual_port);
 

--- a/google/cloud/functions/internal/framework_test.cc
+++ b/google/cloud/functions/internal/framework_test.cc
@@ -127,7 +127,7 @@ TEST(FrameworkTest, CloudEvent) {
   std::promise<int> port_p;
   auto port_f = port_p.get_future();
   std::atomic<bool> shutdown{false};
-  auto hello = [](functions::CloudEvent const&/*event*/) {};
+  auto hello = [](functions::CloudEvent const& /*event*/) {};
   auto run = [&](int argc, char const* const argv[], UserCloudEventFunction f) {
     return RunForTest(
         argc, argv, std::move(f), [&shutdown]() { return shutdown.load(); },

--- a/google/cloud/functions/internal/user_functions.h
+++ b/google/cloud/functions/internal/user_functions.h
@@ -12,22 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_INTERNAL_CALL_USER_FUNCTION_H
-#define FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_INTERNAL_CALL_USER_FUNCTION_H
+#ifndef FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_INTERNAL_USER_FUNCTIONS_H
+#define FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_INTERNAL_USER_FUNCTIONS_H
 
-#include "google/cloud/functions/internal/http_message_types.h"
-#include "google/cloud/functions/internal/user_functions.h"
+#include "google/cloud/functions/cloud_event.h"
+#include "google/cloud/functions/http_request.h"
+#include "google/cloud/functions/http_response.h"
+#include "google/cloud/functions/version.h"
+#include <functional>
 
 namespace google::cloud::functions_internal {
 inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
 
-BeastResponse CallUserFunction(UserHttpFunction const& function,
-                               BeastRequest request);
+using UserHttpFunction =
+    std::function<functions::HttpResponse(functions::HttpRequest)>;
 
-BeastResponse CallUserFunction(UserCloudEventFunction const& function,
-                               BeastRequest const& request);
+using UserCloudEventFunction = std::function<void(functions::CloudEvent)>;
 
 }  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
 }  // namespace google::cloud::functions_internal
 
-#endif  // FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_INTERNAL_CALL_USER_FUNCTION_H
+#endif  // FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_INTERNAL_USER_FUNCTIONS_H


### PR DESCRIPTION
Refactored some duplicate definitions of `UserHttpFunction` and implemented `functions_internal::Run()` for Cloud Events.

Fixes #119.
