### PR TITLE
cleanup: avoid internal-only headers in examples

### DIFF
--- a/examples/hello_from_namespace/hello_from_namespace.cc
+++ b/examples/hello_from_namespace/hello_from_namespace.cc
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <google/cloud/functions/internal/framework.h>
+#include <google/cloud/functions/http_request.h>
+#include <google/cloud/functions/http_response.h>
 
 namespace hello_from_namespace {
 

--- a/examples/hello_from_nested_namespace/hello_from_nested_namespace.cc
+++ b/examples/hello_from_nested_namespace/hello_from_nested_namespace.cc
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <google/cloud/functions/internal/framework.h>
+#include <google/cloud/functions/http_request.h>
+#include <google/cloud/functions/http_response.h>
 
 namespace hello_from_nested_namespace::ns0::ns1 {
 

--- a/examples/hello_gcs/hello_gcs.cc
+++ b/examples/hello_gcs/hello_gcs.cc
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <google/cloud/functions/internal/framework.h>
+#include <google/cloud/functions/http_request.h>
+#include <google/cloud/functions/http_response.h>
 #include <google/cloud/storage/client.h>
 #include <sstream>
 

--- a/examples/hello_multiple_sources/hello_multiple_sources.cc
+++ b/examples/hello_multiple_sources/hello_multiple_sources.cc
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 #include "greeting.h"
-#include <google/cloud/functions/internal/framework.h>
+#include <google/cloud/functions/http_request.h>
+#include <google/cloud/functions/http_response.h>
 
 using ::google::cloud::functions::HttpRequest;
 using ::google::cloud::functions::HttpResponse;

--- a/examples/hello_with_third_party/hello_with_third_party.cc
+++ b/examples/hello_with_third_party/hello_with_third_party.cc
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <google/cloud/functions/internal/framework.h>
+#include <google/cloud/functions/http_request.h>
+#include <google/cloud/functions/http_response.h>
 #include <fmt/core.h>
 
 using ::google::cloud::functions::HttpRequest;

--- a/examples/hello_world/hello_world.cc
+++ b/examples/hello_world/hello_world.cc
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <google/cloud/functions/internal/framework.h>
+#include <google/cloud/functions/http_request.h>
+#include <google/cloud/functions/http_response.h>
 
 using ::google::cloud::functions::HttpRequest;
 using ::google::cloud::functions::HttpResponse;


### PR DESCRIPTION
Fixes #130 