### PR TITLE
feat(CloudEvent): support in build scripts

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -46,6 +46,15 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache/develop
           cache-to: type=local,mode=max,dest=/tmp/.buildx-cache/develop
 
+      - name: build-examples-hello-cloud-event
+        run: >
+          docker build
+          --pull=false
+          --build-arg=FUNCTION_SIGNATURE_TYPE=cloudevent
+          --build-arg=TARGET_FUNCTION=HelloCloudEvent
+          -f build_scripts/build-application.Dockerfile
+          examples/hello_cloud_event
+
       - name: build-examples-multiple-sources
         run: >
           docker build

--- a/build_scripts/vcpkg-overlays/portfile.cmake
+++ b/build_scripts/vcpkg-overlays/portfile.cmake
@@ -4,9 +4,9 @@ vcpkg_from_github(
     REPO
     GoogleCloudPlatform/functions-framework-cpp
     REF
-    4a4a0a534b872b8ea09dd4f6f5d31afab9d02127
+    9b3a8aa80e9e9a5ed6f8793a972d8a9d22231b9b
     SHA512
-    eabb6f96912025ffca090ec8ec5cf7aaffc40bc3f327465dcaf9dd496f2157f32517055e48226917c23dcc0890ed2700dcf8c70822725dc198bca37bfe27dc14
+    869d63232ea544ad49e40b8d515c72bf6ac8896d929122b149953ee2bf73f03ef0d3c32c1de66a37cc50d4c55fd5714875632a317ae296c5ee0a92f21e7fad82
     HEAD_REF
     main)
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -18,6 +18,7 @@ find_package(storage_client REQUIRED)
 
 add_library(
     functions_framework_examples # cmake-format: sort
+    hello_cloud_event/hello_cloud_event.cc
     hello_from_namespace/hello_from_namespace.cc
     hello_from_nested_namespace/hello_from_nested_namespace.cc
     hello_gcs/hello_gcs.cc

--- a/examples/hello_cloud_event/hello_cloud_event.cc
+++ b/examples/hello_cloud_event/hello_cloud_event.cc
@@ -1,0 +1,24 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <google/cloud/functions/cloud_event.h>
+#include <iostream>
+
+using ::google::cloud::functions::CloudEvent;
+
+void HelloCloudEvent(CloudEvent event) {
+  std::cout << "Received event"
+            << "\n id: " << event.id()
+            << "\n subject: " << event.subject().value_or("") << std::endl;
+}

--- a/examples/hello_cloud_event/hello_cloud_event.cc
+++ b/examples/hello_cloud_event/hello_cloud_event.cc
@@ -17,7 +17,7 @@
 
 using ::google::cloud::functions::CloudEvent;
 
-void HelloCloudEvent(CloudEvent event) {
+void HelloCloudEvent(CloudEvent event) {  // NOLINT
   std::cout << "Received event"
             << "\n id: " << event.id()
             << "\n subject: " << event.subject().value_or("") << std::endl;


### PR DESCRIPTION
This adds support for Cloud Events in the build scripts, including the
new signature type (`cloudevent`). To test the scripts this also adds a
"Hello World"-type example.

Fixes #62 and fixes #63 