### PR TITLE
test: initial unit tests for examples

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -35,3 +35,20 @@ add_library(
     site/http_xml/http_xml.cc)
 target_link_libraries(functions_framework_examples storage_client
                       googleapis-c++::functions_framework)
+
+if (BUILD_TESTING)
+    find_package(GTest CONFIG REQUIRED)
+    set(googleapis_functions_framework_examples_unit_tests # cmake-format: sort
+                                                           site_test.cc)
+
+    foreach (fname ${googleapis_functions_framework_examples_unit_tests})
+        string(REPLACE "/" "_" target "${fname}")
+        string(REPLACE ".cc" "" target "${target}")
+        add_executable("${target}" ${fname})
+        target_link_libraries(
+            ${target}
+            PRIVATE functions_framework_examples googleapis_functions_framework
+                    GTest::gmock_main GTest::gmock GTest::gtest)
+        add_test(NAME ${target} COMMAND ${target})
+    endforeach ()
+endif ()

--- a/examples/site/hello_world_content/hello_world_content.cc
+++ b/examples/site/hello_world_content/hello_world_content.cc
@@ -18,6 +18,7 @@
 #include <nlohmann/json.hpp>
 #include <algorithm>
 #include <charconv>
+#include <iostream>
 #include <iterator>
 #include <map>
 #include <sstream>
@@ -36,11 +37,11 @@ gcf::HttpResponse hello_world_content(gcf::HttpRequest request) {  // NOLINT
   auto const& headers = request.headers();
   if (auto f = headers.find("content-type"); f != headers.end()) {
     if (f->second == "application/json") {
-      name = nlohmann::json(request.payload()).value("name", "");
+      name = nlohmann::json::parse(request.payload()).value("name", "");
     } else if (f->second == "application/octet-stream" ||
                f->second == "text/plain") {
       name = request.payload();  // treat contents as a string
-    } else if (f->second == "application/x-www-form-urlencoded'") {
+    } else if (f->second == "application/x-www-form-urlencoded") {
       // Use your preferred parser, here we use some custom code.
       auto form = parse_www_form_urlencoded(request.payload());
       name = form["name"];

--- a/examples/site/hello_world_content/hello_world_content.cc
+++ b/examples/site/hello_world_content/hello_world_content.cc
@@ -16,10 +16,7 @@
 #include <google/cloud/functions/http_request.h>
 #include <google/cloud/functions/http_response.h>
 #include <nlohmann/json.hpp>
-#include <algorithm>
 #include <charconv>
-#include <iostream>
-#include <iterator>
 #include <map>
 #include <sstream>
 #include <string>

--- a/examples/site_test.cc
+++ b/examples/site_test.cc
@@ -56,6 +56,10 @@ TEST(ExamplesSiteTest, HelloWorldContent) {
   actual = hello_world_content(make_request("application/x-www-form-urlencoded",
                                             "id=1&name=Baz%20Qux&value=x"));
   EXPECT_THAT(actual.payload(), "Hello Baz Qux");
+
+  actual = hello_world_content(make_request("application/x-www-form-urlencoded",
+                                            "id=1&name=Baz%Qux&value=x"));
+  EXPECT_THAT(actual.payload(), "Hello Baz%Qux");
 }
 
 TEST(ExamplesSiteTest, HelloWorldGet) {

--- a/examples/site_test.cc
+++ b/examples/site_test.cc
@@ -1,0 +1,179 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/functions/http_request.h"
+#include "google/cloud/functions/http_response.h"
+#include "google/cloud/functions/mocks/mock_http_request.h"
+#include <gmock/gmock.h>
+
+namespace gcf = ::google::cloud::functions;
+extern gcf::HttpResponse hello_world_content(gcf::HttpRequest request);
+extern gcf::HttpResponse hello_world_get(gcf::HttpRequest request);
+extern gcf::HttpResponse http_cors(gcf::HttpRequest request);
+extern gcf::HttpResponse http_cors_auth(gcf::HttpRequest request);
+extern gcf::HttpResponse http_method(gcf::HttpRequest request);
+extern gcf::HttpResponse http_xml(gcf::HttpRequest request);
+
+namespace {
+
+using ::google::cloud::functions_mocks::MockHttpRequest;
+using ::testing::AtLeast;
+using ::testing::ReturnRefOfCopy;
+
+TEST(ExamplesSiteTest, HelloWorldContent) {
+  auto make_request = [](std::string const& content_type,
+                         std::string const& payload) {
+    auto mock = std::make_unique<MockHttpRequest>();
+    EXPECT_CALL(*mock, payload)
+        .Times(AtLeast(1))
+        .WillRepeatedly(ReturnRefOfCopy(payload));
+    gcf::HttpRequest::HeadersType headers;
+    headers.emplace("content-type", content_type);
+    EXPECT_CALL(*mock, headers)
+        .Times(AtLeast(1))
+        .WillRepeatedly(ReturnRefOfCopy(headers));
+    return gcf::HttpRequest(std::move(mock));
+  };
+
+  auto actual = hello_world_content(
+      make_request("application/json", R"js({ "name": "Foo" })js"));
+  EXPECT_THAT(actual.payload(), "Hello Foo");
+
+  actual = hello_world_content(make_request("text/plain", "Bar"));
+  EXPECT_THAT(actual.payload(), "Hello Bar");
+
+  actual = hello_world_content(make_request("application/x-www-form-urlencoded",
+                                            "id=1&name=Baz%20Qux&value=x"));
+  EXPECT_THAT(actual.payload(), "Hello Baz Qux");
+}
+
+TEST(ExamplesSiteTest, HelloWorldGet) {
+  auto make_request = [](std::string const& payload) {
+    auto mock = std::make_unique<MockHttpRequest>();
+    EXPECT_CALL(*mock, payload)
+        .Times(AtLeast(1))
+        .WillRepeatedly(ReturnRefOfCopy(payload));
+    return gcf::HttpRequest(std::move(mock));
+  };
+
+  auto actual = hello_world_get(make_request(R"js({ "name": "Foo" })js"));
+  EXPECT_EQ(actual.payload(), "Hello Foo");
+
+  actual = hello_world_get(make_request(R"js({ "unused": 7 })js"));
+  EXPECT_EQ(actual.payload(), "Hello World");
+
+  actual = hello_world_get(make_request("Bar"));
+  EXPECT_EQ(actual.payload(), "Hello World");
+}
+
+TEST(ExamplesSiteTest, HttpCors) {
+  auto make_options_request = [] {
+    auto mock = std::make_unique<MockHttpRequest>();
+    EXPECT_CALL(*mock, verb)
+        .Times(AtLeast(1))
+        .WillRepeatedly(ReturnRefOfCopy(std::string("OPTIONS")));
+    return gcf::HttpRequest(std::move(mock));
+  };
+  auto make_get_request = []() {
+    auto mock = std::make_unique<MockHttpRequest>();
+    EXPECT_CALL(*mock, verb)
+        .Times(AtLeast(1))
+        .WillRepeatedly(ReturnRefOfCopy(std::string("GET")));
+    return gcf::HttpRequest(std::move(mock));
+  };
+
+  auto actual = http_cors(make_options_request());
+  EXPECT_EQ(actual.headers().at("Access-Control-Allow-Methods"), "GET");
+
+  actual = http_cors(make_get_request());
+  EXPECT_EQ(actual.headers().at("Access-Control-Allow-Origin"), "*");
+  EXPECT_EQ(actual.payload(), "Hello World!");
+}
+
+TEST(ExamplesSiteTest, HttpCorsAuth) {
+  auto make_options_request = [] {
+    auto mock = std::make_unique<MockHttpRequest>();
+    EXPECT_CALL(*mock, verb)
+        .Times(AtLeast(1))
+        .WillRepeatedly(ReturnRefOfCopy(std::string("OPTIONS")));
+    return gcf::HttpRequest(std::move(mock));
+  };
+  auto make_get_request = [] {
+    auto mock = std::make_unique<MockHttpRequest>();
+    EXPECT_CALL(*mock, verb)
+        .Times(AtLeast(1))
+        .WillRepeatedly(ReturnRefOfCopy(std::string("GET")));
+    return gcf::HttpRequest(std::move(mock));
+  };
+
+  auto actual = http_cors_auth(make_options_request());
+  EXPECT_EQ(actual.headers().at("Access-Control-Allow-Headers"),
+            "Authorization");
+
+  actual = http_cors_auth(make_get_request());
+  EXPECT_EQ(actual.headers().at("Access-Control-Allow-Origin"),
+            "https://mydomain.com");
+  EXPECT_EQ(actual.headers().at("Access-Control-Allow-Credentials"), "true");
+  EXPECT_EQ(actual.payload(), "Hello World!");
+}
+
+TEST(ExamplesSiteTest, HttpMethod) {
+  struct Test {
+    std::string verb;
+    int result;
+  } tests[] = {
+      {"GET", gcf::HttpResponse::kOkay},
+      {"POST", gcf::HttpResponse::kForbidden},
+      {"PUT", gcf::HttpResponse::kMethodNotAllowed},
+  };
+
+  auto make_request = [](std::string const& verb) {
+    auto mock = std::make_unique<MockHttpRequest>();
+    EXPECT_CALL(*mock, verb)
+        .Times(AtLeast(1))
+        .WillRepeatedly(ReturnRefOfCopy(verb));
+    return gcf::HttpRequest(std::move(mock));
+  };
+
+  for (auto const& test : tests) {
+    auto actual = http_method(make_request(test.verb));
+    EXPECT_EQ(actual.result(), test.result);
+  }
+}
+
+TEST(ExamplesSiteTest, HelloWorldXml) {
+  auto make_request = [](std::string const& payload) {
+    auto mock = std::make_unique<MockHttpRequest>();
+    EXPECT_CALL(*mock, payload)
+        .Times(AtLeast(1))
+        .WillRepeatedly(ReturnRefOfCopy(payload));
+    return gcf::HttpRequest(std::move(mock));
+  };
+
+  auto actual = http_xml(make_request(R"xml(
+<name>Foo</name>
+<unused1>Bar</unused1>
+<unused2>Baz</unused2>
+)xml"));
+  EXPECT_EQ(actual.payload(), "Hello Foo");
+
+  actual = http_xml(make_request(R"xml(
+<unused>Foo</unused>
+<unused1>Bar</unused1>
+<unused2>Baz</unused2>
+)xml"));
+  EXPECT_EQ(actual.payload(), "Hello World");
+}
+
+}  // namespace

--- a/google/cloud/functions/CMakeLists.txt
+++ b/google/cloud/functions/CMakeLists.txt
@@ -71,23 +71,23 @@ set_target_properties(
 add_library(googleapis-c++::functions_framework ALIAS
             googleapis_functions_framework)
 
+add_library(googleapis_functions_framework_mocks INTERFACE)
+target_sources(
+    googleapis_functions_framework_mocks
+    INTERFACE # cmake-format: sort
+              ${CMAKE_CURRENT_SOURCE_DIR}/mocks/mock_http_request.h)
+target_link_libraries(
+    googleapis_functions_framework_mocks
+    INTERFACE googleapis-c++::functions_framework GTest::gmock_main
+              GTest::gmock GTest::gtest)
+target_include_directories(
+    googleapis_functions_framework_mocks
+    INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+              $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
+              $<INSTALL_INTERFACE:include>)
+
 if (BUILD_TESTING)
     find_package(GTest CONFIG REQUIRED)
-
-    add_library(googleapis_functions_framework_mocks INTERFACE)
-    target_sources(
-        googleapis_functions_framework_mocks
-        INTERFACE # cmake-format: sort
-                  ${CMAKE_CURRENT_SOURCE_DIR}/mocks/mock_http_request.h)
-    target_link_libraries(
-        googleapis_functions_framework_mocks
-        INTERFACE googleapis-c++::functions_framework GTest::gmock_main
-                  GTest::gmock GTest::gtest)
-    target_include_directories(
-        googleapis_functions_framework_mocks
-        INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
-                  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
-                  $<INSTALL_INTERFACE:include>)
 
     set(googleapis_functions_framework_unit_tests
         # cmake-format: sort

--- a/google/cloud/functions/CMakeLists.txt
+++ b/google/cloud/functions/CMakeLists.txt
@@ -73,6 +73,22 @@ add_library(googleapis-c++::functions_framework ALIAS
 
 if (BUILD_TESTING)
     find_package(GTest CONFIG REQUIRED)
+
+    add_library(googleapis_functions_framework_mocks INTERFACE)
+    target_sources(
+        googleapis_functions_framework_mocks
+        INTERFACE # cmake-format: sort
+                  ${CMAKE_CURRENT_SOURCE_DIR}/mocks/mock_http_request.h)
+    target_link_libraries(
+        googleapis_functions_framework_mocks
+        INTERFACE googleapis-c++::functions_framework GTest::gmock_main
+                  GTest::gmock GTest::gtest)
+    target_include_directories(
+        googleapis_functions_framework_mocks
+        INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+                  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
+                  $<INSTALL_INTERFACE:include>)
+
     set(googleapis_functions_framework_unit_tests
         # cmake-format: sort
         cloud_event_test.cc
@@ -118,6 +134,8 @@ install(
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT development)
 
 google_cloud_cpp_install_headers(googleapis_functions_framework
+                                 include/google/cloud/functions)
+google_cloud_cpp_install_headers(googleapis_functions_framework_mocks
                                  include/google/cloud/functions)
 
 # Create and install the CMake configuration files.

--- a/google/cloud/functions/mocks/mock_http_request.h
+++ b/google/cloud/functions/mocks/mock_http_request.h
@@ -24,12 +24,23 @@ inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
 
 class MockHttpRequest : public google::cloud::functions::HttpRequest::Impl {
  public:
+  // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
   MOCK_METHOD(std::string const&, verb, (), (const override));
+
+  // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
   MOCK_METHOD(std::string const&, target, (), (const override));
+
+  // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
   MOCK_METHOD(std::string const&, payload, (), (const override));
+
+  // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
   MOCK_METHOD(google::cloud::functions::HttpRequest::HeadersType const&,
               headers, (), (const override));
+
+  // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
   MOCK_METHOD(int, version_major, (), (const override));
+
+  // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
   MOCK_METHOD(int, version_minor, (), (const override));
 };
 

--- a/google/cloud/functions/mocks/mock_http_request.h
+++ b/google/cloud/functions/mocks/mock_http_request.h
@@ -1,0 +1,39 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_MOCKS_MOCK_HTTP_REQUEST_H
+#define FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_MOCKS_MOCK_HTTP_REQUEST_H
+
+#include "google/cloud/functions/http_request.h"
+#include "google/cloud/functions/version.h"
+#include <gmock/gmock.h>
+
+namespace google::cloud::functions_mocks {
+inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+
+class MockHttpRequest : public google::cloud::functions::HttpRequest::Impl {
+ public:
+  MOCK_METHOD(std::string const&, verb, (), (const override));
+  MOCK_METHOD(std::string const&, target, (), (const override));
+  MOCK_METHOD(std::string const&, payload, (), (const override));
+  MOCK_METHOD(google::cloud::functions::HttpRequest::HeadersType const&,
+              headers, (), (const override));
+  MOCK_METHOD(int, version_major, (), (const override));
+  MOCK_METHOD(int, version_minor, (), (const override));
+};
+
+}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+}  // namespace google::cloud::functions_mocks
+
+#endif  // FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_MOCKS_MOCK_HTTP_REQUEST_H


### PR DESCRIPTION
This introduces the first unit test for the examples, and some support
mocks to write such tests. The mock should be part of the public API, as
application developers may want to use them.