### PR TITLE
feat: implement functions_helloworld_http example

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(
     hello_world/hello_world.cc
     site/hello_world_content/hello_world_content.cc
     site/hello_world_get/hello_world_get.cc
+    site/hello_world_http/hello_world_http.cc
     site/http_cors/http_cors.cc
     site/http_cors_auth/http_cors_auth.cc
     site/http_method/http_method.cc

--- a/examples/site/hello_world_http/hello_world_http.cc
+++ b/examples/site/hello_world_http/hello_world_http.cc
@@ -12,17 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// [START functions_helloworld_get]
+// [START functions_helloworld_http]
 #include <google/cloud/functions/http_request.h>
 #include <google/cloud/functions/http_response.h>
 #include <nlohmann/json.hpp>
 
 namespace gcf = ::google::cloud::functions;
 
-gcf::HttpResponse hello_world_get(gcf::HttpRequest) {  // NOLINT
+gcf::HttpResponse hello_world_http(gcf::HttpRequest request) {
+  auto greeting = [r = std::move(request)] {
+    auto request_json = nlohmann::json::parse(r.payload(), /*cb=*/nullptr,
+                                              /*allow_exceptions=*/false);
+    if (request_json.count("name") && request_json["name"].is_string()) {
+      return "Hello " + request_json.value("name", "World") + "!";
+    }
+    return std::string("Hello World!");
+  };
+
   gcf::HttpResponse response;
-  response.set_payload("Hello World!");
+  response.set_payload(greeting());
   response.set_header("content-type", "text/plain");
   return response;
 }
-// [END functions_helloworld_get]
+// [END functions_helloworld_http]

--- a/examples/site_test.cc
+++ b/examples/site_test.cc
@@ -19,6 +19,7 @@
 namespace gcf = ::google::cloud::functions;
 extern gcf::HttpResponse hello_world_content(gcf::HttpRequest request);
 extern gcf::HttpResponse hello_world_get(gcf::HttpRequest request);
+extern gcf::HttpResponse hello_world_http(gcf::HttpRequest request);
 extern gcf::HttpResponse http_cors(gcf::HttpRequest request);
 extern gcf::HttpResponse http_cors_auth(gcf::HttpRequest request);
 extern gcf::HttpResponse http_method(gcf::HttpRequest request);
@@ -50,16 +51,21 @@ TEST(ExamplesSiteTest, HelloWorldContent) {
 }
 
 TEST(ExamplesSiteTest, HelloWorldGet) {
-  auto actual = hello_world_get(
+  auto actual = hello_world_get(gcf::HttpRequest{});
+  EXPECT_EQ(actual.payload(), "Hello World!");
+}
+
+TEST(ExamplesSiteTest, HelloWorlHttp) {
+  auto actual = hello_world_http(
       gcf::HttpRequest{}.set_payload(R"js({ "name": "Foo" })js"));
-  EXPECT_EQ(actual.payload(), "Hello Foo");
+  EXPECT_EQ(actual.payload(), "Hello Foo!");
 
-  actual =
-      hello_world_get(gcf::HttpRequest{}.set_payload(R"js({ "unused": 7 })js"));
-  EXPECT_EQ(actual.payload(), "Hello World");
+  actual = hello_world_http(
+      gcf::HttpRequest{}.set_payload(R"js({ "unused": 7 })js"));
+  EXPECT_EQ(actual.payload(), "Hello World!");
 
-  actual = hello_world_get(gcf::HttpRequest{}.set_payload("Bar"));
-  EXPECT_EQ(actual.payload(), "Hello World");
+  actual = hello_world_http(gcf::HttpRequest{}.set_payload("Bar"));
+  EXPECT_EQ(actual.payload(), "Hello World!");
 }
 
 TEST(ExamplesSiteTest, HttpCors) {


### PR DESCRIPTION
Implement the `helloworld_http` example and fix `helloworld_get`. Seems
like I got confused when I was reading the examples for other languages.