### PR TITLE
ci: speed up Docker script to build images

### DIFF
--- a/build_scripts/build-application.Dockerfile
+++ b/build_scripts/build-application.Dockerfile
@@ -20,16 +20,15 @@ ARG FUNCTION_SIGNATURE_TYPE="http"
 COPY --chown=cnb --from=parent /layers/cpp/gcf/cmake /workspace
 COPY --chown=cnb . /workspace/application
 
-RUN if [ -r /workspace/application/vcpkg.json ]; then cp /workspace/application/vcpkg.json /workspace; fi
-RUN /layers/cpp/gcf/generate-wrapper.sh "${TARGET_FUNCTION}" "${FUNCTION_SIGNATURE_TYPE}" >/workspace/main.cc
-
 ENV VCPKG_DEFAULT_BINARY_CACHE=/layers/cpp/vcpkg-cache
 ENV VCPKG_OVERLAY_PORTS=/layers/cpp/gcf/vcpkg-overlays
 
-RUN /layers/cpp/cmake/bin/cmake -S /workspace -B /var/tmp/build -GNinja \
-    -DCMAKE_INSTALL_PREFIX=/var/tmp/install \
-    -DCMAKE_TOOLCHAIN_FILE=/layers/cpp/vcpkg/scripts/buildsystems/vcpkg.cmake
-RUN /layers/cpp/cmake/bin/cmake --build /var/tmp/build --target install
+RUN if [ -r /workspace/application/vcpkg.json ]; then cp /workspace/application/vcpkg.json /workspace; fi \
+    && /layers/cpp/gcf/generate-wrapper.sh "${TARGET_FUNCTION}" "${FUNCTION_SIGNATURE_TYPE}" >/workspace/main.cc \
+    && /layers/cpp/cmake/bin/cmake -S /workspace -B /var/tmp/build -GNinja \
+           -DCMAKE_INSTALL_PREFIX=/var/tmp/install \
+           -DCMAKE_TOOLCHAIN_FILE=/layers/cpp/vcpkg/scripts/buildsystems/vcpkg.cmake \
+    && /layers/cpp/cmake/bin/cmake --build /var/tmp/build --target install
 
 FROM gcf-cpp-runtime AS runtime
 COPY --from=application /var/tmp/install/bin/function /r/application


### PR DESCRIPTION
This reduces the number of layers in the image, and as each layer is
"saved" and "committed", the fewer layers the less I/O, the faster the
build process (and our CIs).