### PR TITLE
cleanup: improve testing for non-site examples

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -15,6 +15,7 @@
 # ~~~
 
 find_package(storage_client REQUIRED)
+find_package(fmt REQUIRED)
 
 add_library(
     functions_framework_examples # cmake-format: sort
@@ -34,13 +35,14 @@ add_library(
     site/http_cors_auth/http_cors_auth.cc
     site/http_method/http_method.cc
     site/http_xml/http_xml.cc)
-target_link_libraries(functions_framework_examples storage_client
+target_link_libraries(functions_framework_examples storage_client fmt::fmt
                       googleapis-c++::functions_framework)
 
 if (BUILD_TESTING)
     find_package(GTest CONFIG REQUIRED)
-    set(googleapis_functions_framework_examples_unit_tests # cmake-format: sort
-                                                           site_test.cc)
+    set(googleapis_functions_framework_examples_unit_tests
+        # cmake-format: sort
+        cloud_event_examples_test.cc http_examples_test.cc site_test.cc)
 
     foreach (fname ${googleapis_functions_framework_examples_unit_tests})
         string(REPLACE "/" "_" target "${fname}")

--- a/examples/cloud_event_examples_test.cc
+++ b/examples/cloud_event_examples_test.cc
@@ -1,0 +1,48 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/functions/internal/parse_cloud_event_json.h"
+#include "google/cloud/functions/cloud_event.h"
+#include <gmock/gmock.h>
+
+namespace gcf = ::google::cloud::functions;
+
+void HelloCloudEvent(gcf::CloudEvent event);
+
+namespace {
+
+TEST(HttpExamplesTest, HelloCloudEvent) {
+  EXPECT_NO_THROW(HelloCloudEvent(
+      google::cloud::functions_internal::ParseCloudEventJson(R"js({
+    "specversion": "1.0",
+    "type": "google.cloud.pubsub.topic.v1.messagePublished",
+    "source": "//pubsub.googleapis.com/projects/sample-project/topics/gcf-test",
+    "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
+    "subject": "test-only",
+    "time": "2020-09-29T11:32:00.000Z",
+    "datacontenttype": "application/json",
+    "data": {
+      "subscription": "projects/sample-project/subscriptions/sample-subscription",
+      "message": {
+        "@type": "type.googleapis.com/google.pubsub.v1.PubsubMessage",
+        "attributes": {
+           "attr1":"attr1-value"
+        },
+        "data": ""
+      }
+    }
+  })js")));
+}
+
+}  // namespace

--- a/examples/http_examples_test.cc
+++ b/examples/http_examples_test.cc
@@ -1,0 +1,70 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/functions/http_request.h"
+#include "google/cloud/functions/http_response.h"
+#include <gmock/gmock.h>
+
+namespace gcf = ::google::cloud::functions;
+
+gcf::HttpResponse HelloGcs(gcf::HttpRequest);
+gcf::HttpResponse HelloMultipleSources(gcf::HttpRequest);
+gcf::HttpResponse HelloWithThirdParty(gcf::HttpRequest request);
+gcf::HttpResponse HelloWorld(gcf::HttpRequest);
+
+namespace hello_from_namespace {
+gcf::HttpResponse HelloWorld(gcf::HttpRequest);
+}  // namespace hello_from_namespace
+
+namespace hello_from_nested_namespace::ns0::ns1 {
+gcf::HttpResponse HelloWorld(gcf::HttpRequest);
+}  // namespace hello_from_nested_namespace::ns0::ns1
+
+namespace {
+
+using ::testing::HasSubstr;
+
+TEST(HttpExamplesTest, HelloGcs) {
+  auto const actual = HelloGcs(gcf::HttpRequest{}.set_target("/"));
+  EXPECT_EQ(actual.result(), gcf::HttpResponse::kBadRequest);
+}
+
+TEST(HttpExamplesTest, HelloMultipleSources) {
+  auto const actual = HelloMultipleSources(gcf::HttpRequest{});
+  EXPECT_THAT(actual.payload(), HasSubstr("Hello World"));
+}
+
+TEST(HttpExamplesTest, HelloWithThirdParty) {
+  auto const actual =
+      HelloWithThirdParty(gcf::HttpRequest{}.set_target("/here"));
+  EXPECT_THAT(actual.payload(), HasSubstr("Hello at /here"));
+}
+
+TEST(HttpExamplesTest, HelloWorld) {
+  auto const actual = HelloWorld(gcf::HttpRequest{});
+  EXPECT_THAT(actual.payload(), HasSubstr("Hello World"));
+}
+
+TEST(HttpExamplesTest, HelloFromNamespace) {
+  auto const actual = hello_from_namespace::HelloWorld(gcf::HttpRequest{});
+  EXPECT_THAT(actual.payload(), HasSubstr("C++ namespace"));
+}
+
+TEST(HttpExamplesTest, HelloFromNestedNamespace) {
+  auto const actual =
+      hello_from_nested_namespace::ns0::ns1::HelloWorld(gcf::HttpRequest{});
+  EXPECT_THAT(actual.payload(), HasSubstr("C++ namespace"));
+}
+
+}  // namespace


### PR DESCRIPTION
We have some examples that are specific to the framework, and do not
follow the region tags or any other conventions from the cloud site.
These were not tested, now they are.

The GCS example needs an integration test, but we have not figured out
how to do that just yet.