### PR TITLE
cleanup: prefer /usr/local for development tools

### DIFF
--- a/build_scripts/Dockerfile
+++ b/build_scripts/Dockerfile
@@ -34,7 +34,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN apt-get update \
     && apt-get install -y libc++1-9 \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 LABEL io.buildpacks.stack.id=${stack_id}
+
 RUN groupadd cnb --gid ${cnb_gid} && \
   useradd --uid ${cnb_uid} --gid ${cnb_gid} -m -s /bin/bash cnb
 
@@ -46,64 +48,73 @@ FROM parent AS gcf-cpp-runtime
 ENV PORT 8080
 USER cnb
 
-FROM parent AS gcf-cpp-incremental-0
+FROM parent AS gcf-cpp-incremental
 RUN apt-get update \
-    && apt install -y build-essential g++-8 gcc-8 git libstdc++-8-dev pkg-config ninja-build tar unzip zip \
-    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 100 \
-    && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 100 \
+    && apt install -y  --no-install-recommends \
+       build-essential g++-8 gcc-8 git libstdc++-8-dev pkg-config tar unzip zip \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 100 \
+    && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 100
 
-WORKDIR /layers/cpp
-RUN chown cnb /layers/cpp
-USER cnb
-
-RUN mkdir -p /layers/cpp/cmake /layers/cpp/vcpkg /layers/cpp/vcpkg-cache /layers/cpp/functions-framework-cpp
-
-RUN cd /layers/cpp/cmake && \
-    curl -sSL https://github.com/Kitware/CMake/releases/download/v3.18.4/cmake-3.18.4-Linux-x86_64.tar.gz | \
+WORKDIR /usr/local
+RUN curl -sSL https://github.com/Kitware/CMake/releases/download/v3.19.2/cmake-3.19.2-Linux-x86_64.tar.gz | \
     tar -xzf - --strip-components=1
 
-RUN cd /layers/cpp/vcpkg && \
-    curl -sSL https://github.com/Microsoft/vcpkg/archive/5dc53211caedebf4387d590155ed53ee44161f10.tar.gz | \
+RUN curl -sSL https://github.com/ninja-build/ninja/releases/download/v1.10.2/ninja-linux.zip | \
+    funzip >/usr/local/bin/ninja && \
+    chmod 755 /usr/local/bin/ninja
+WORKDIR /usr/local/vcpkg
+RUN curl -sSL https://github.com/Microsoft/vcpkg/archive/5dc53211caedebf4387d590155ed53ee44161f10.tar.gz | \
     tar -xzf - --strip-components=1 && \
-    ./bootstrap-vcpkg.sh -disableMetrics
+    ./bootstrap-vcpkg.sh -disableMetrics -useSystemBinaries && \
+    rm -fr toolsrc/build.rel downloads/*
 
-ENV VCPKG_DEFAULT_BINARY_CACHE=/layers/cpp/vcpkg-cache
+WORKDIR /var/cache/vcpkg-cache
+ENV VCPKG_DEFAULT_BINARY_CACHE=/var/cache/vcpkg-cache
 
 # These are needed by the Functions Framework, do them one at a time, easier to
 # rebuild the Docker image if one of them fails to download or something.
-FROM gcf-cpp-incremental-0 AS gcf-cpp-incremental-1
-RUN /layers/cpp/vcpkg/vcpkg install --clean-after-build boost-core
-FROM gcf-cpp-incremental-1 AS gcf-cpp-incremental-2
-RUN /layers/cpp/vcpkg/vcpkg install --clean-after-build openssl
-FROM gcf-cpp-incremental-2 AS gcf-cpp-incremental-3
-RUN /layers/cpp/vcpkg/vcpkg install --clean-after-build boost-program-options
-FROM gcf-cpp-incremental-3 AS gcf-cpp-incremental-4
-RUN /layers/cpp/vcpkg/vcpkg install --clean-after-build boost-asio
-FROM gcf-cpp-incremental-4 AS gcf-cpp-incremental-5
-RUN /layers/cpp/vcpkg/vcpkg install --clean-after-build boost-beast
+RUN /usr/local/vcpkg/vcpkg install --clean-after-build abseil
+RUN /usr/local/vcpkg/vcpkg install --clean-after-build boost-core
+RUN /usr/local/vcpkg/vcpkg install --clean-after-build openssl
+RUN /usr/local/vcpkg/vcpkg install --clean-after-build boost-program-options
+RUN /usr/local/vcpkg/vcpkg install --clean-after-build boost-asio
+RUN /usr/local/vcpkg/vcpkg install --clean-after-build boost-beast
+RUN /usr/local/vcpkg/vcpkg install --clean-after-build boost-serialization
+RUN /usr/local/vcpkg/vcpkg install --clean-after-build nlohmann-json
 
 # The following are not needed by the Functions Framework, but are used often
 # enough that it is a good idea to make them part of the base development
 # environment. Note that this automatically pulls abseil, grpc, protobuf, curl,
 # and a few other libraries.
-FROM gcf-cpp-incremental-5 AS gcf-cpp-incremental-6
-RUN /layers/cpp/vcpkg/vcpkg install --clean-after-build curl
-FROM gcf-cpp-incremental-6 AS gcf-cpp-incremental-7
-RUN /layers/cpp/vcpkg/vcpkg install --clean-after-build abseil
-RUN /layers/cpp/vcpkg/vcpkg install --clean-after-build protobuf
-RUN /layers/cpp/vcpkg/vcpkg install --clean-after-build grpc
-FROM gcf-cpp-incremental-7 AS gcf-cpp-incremental-8
-RUN /layers/cpp/vcpkg/vcpkg install --clean-after-build google-cloud-cpp
-RUN echo "DISABLED: /layers/cpp/vcpkg/vcpkg install boost"
+RUN /usr/local/vcpkg/vcpkg install --clean-after-build curl
+RUN /usr/local/vcpkg/vcpkg install --clean-after-build protobuf
+RUN /usr/local/vcpkg/vcpkg install --clean-after-build grpc
+RUN /usr/local/vcpkg/vcpkg install --clean-after-build google-cloud-cpp
 
-FROM gcf-cpp-incremental-8 AS gcf-cpp-develop
+RUN /usr/local/vcpkg/vcpkg list | awk '{print $1}' | xargs /usr/local/vcpkg/vcpkg remove --recurse
+
+FROM parent AS gcf-cpp-develop
+RUN apt-get update \
+    && apt install -y  --no-install-recommends \
+       build-essential g++-8 gcc-8 git libstdc++-8-dev pkg-config tar unzip zip \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 100 \
+    && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 100
+
+COPY --from=gcf-cpp-incremental /usr/local/bin/cmake   /usr/local/bin/cmake
+COPY --from=gcf-cpp-incremental /usr/local/bin/ctest   /usr/local/bin/ctest
+COPY --from=gcf-cpp-incremental /usr/local/bin/ninja   /usr/local/bin/ninja
+COPY --from=gcf-cpp-incremental /usr/local/share /usr/local/share
+COPY --from=gcf-cpp-incremental /usr/local/vcpkg /usr/local/vcpkg
+COPY --from=gcf-cpp-incremental /var/cache/vcpkg-cache /var/cache/vcpkg-cache
 
 # TODO(#41) - switch to the actual vcpkg package once created.
-RUN mkdir -p /layers/cpp/gcf/cmake /layers/cpp/gcf/vcpkg-overlays
-COPY --chown=cnb vcpkg-overlays /layers/cpp/gcf/vcpkg-overlays
-RUN /layers/cpp/vcpkg/vcpkg install --clean-after-build \
-    --overlay-ports=/layers/cpp/gcf/vcpkg-overlays functions-framework-cpp
+COPY vcpkg-overlays      /usr/local/share/gcf/vcpkg-overlays
+COPY generate-wrapper.sh /usr/local/share/gcf
+COPY cmake               /usr/local/share/gcf/cmake
+RUN find /usr/local/share/gcf -type f | xargs chmod 644
+RUN find /usr/local/share/gcf -type d | xargs chmod 755
+RUN chmod 755 /usr/local/share/gcf/generate-wrapper.sh
 
-COPY --chown=cnb generate-wrapper.sh /layers/cpp/gcf
-COPY --chown=cnb cmake /layers/cpp/gcf/cmake
+USER cnb

--- a/examples/hello_gcs/vcpkg.json
+++ b/examples/hello_gcs/vcpkg.json
@@ -1,0 +1,8 @@
+{
+  "name": "hello-gcs",
+  "version-string": "unversioned",
+  "dependencies": [
+    "google-cloud-cpp",
+    "functions-framework-cpp"
+  ]
+}

--- a/pack/buildpack/bin/build
+++ b/pack/buildpack/bin/build
@@ -19,13 +19,18 @@ echo "---> Functions Framework C++ Buildpack"
 
 layers="$1"
 
-echo "-----> Setup vcpkg cache"
-export VCPKG_DEFAULT_BINARY_CACHE=${layers}/vcpkg
-export VCPKG_OVERLAY_PORTS=/layers/cpp/gcf/vcpkg-overlays
+echo "-----> Setup vcpkg"
+export VCPKG_DEFAULT_BINARY_CACHE=${layers}/vcpkg/vcpkg-cache
+export VCPKG_OVERLAY_PORTS=/usr/local/share/gcf/vcpkg-overlays
 if [[ ! -d "${layers}/vcpkg" ]]; then
-  echo "-----> Restore cache from build image"
-  cp -r /layers/cpp/vcpkg-cache "${layers}/vcpkg"
+  echo "-----> Restore vcpkg from build image"
+  cp -r /usr/local/vcpkg "${layers}"
 fi
+if [[ ! -d "${layers}/vcpkg/vcpkg-cache" ]]; then
+  echo "-----> Restore cache from build image"
+  cp -r /var/cache/vcpkg-cache "${layers}/vcpkg/vcpkg-cache"
+fi
+"${layers}/vcpkg/vcpkg" install functions-framework-cpp
 cat > "${layers}/vcpkg.toml" <<EOL
 build = true
 cache = true
@@ -39,11 +44,11 @@ cache = false
 launch = false
 EOL
 
-cp -r /layers/cpp/gcf/cmake "${layers}/source"
+cp -r /usr/local/share/gcf/cmake "${layers}/source"
 if [[ -r vcpkg.json ]]; then
   cp vcpkg.json "${layers}/source"
 fi
-/layers/cpp/gcf/generate-wrapper.sh "${TARGET_FUNCTION}" "${FUNCTION_SIGNATURE_TYPE:-http}" >"${layers}/source/main.cc"
+/usr/local/share/gcf/generate-wrapper.sh "${TARGET_FUNCTION}" "${FUNCTION_SIGNATURE_TYPE:-http}" >"${layers}/source/main.cc"
 
 echo "-----> Configure Function"
 cat > "${layers}/binary.toml" <<EOL
@@ -52,13 +57,13 @@ cache = true
 launch = false
 EOL
 
-/layers/cpp/cmake/bin/cmake -S "${layers}/source" -B "${layers}/binary" -GNinja \
+/usr/local/bin/cmake -S "${layers}/source" -B "${layers}/binary" -GNinja -DCMAKE_MAKE_PROGRAM=/usr/local/bin/ninja \
   -DCNB_APP_DIR="${PWD}" \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_INSTALL_PREFIX="${layers}/local" \
-  -DCMAKE_TOOLCHAIN_FILE="/layers/cpp/vcpkg/scripts/buildsystems/vcpkg.cmake"
+  -DCMAKE_TOOLCHAIN_FILE="${layers}/vcpkg/scripts/buildsystems/vcpkg.cmake"
 echo "-----> Compile and Install Function``"
-/layers/cpp/cmake/bin/cmake --build "${layers}/binary" --target install
+/usr/local/bin/cmake --build "${layers}/binary" --target install
 
 cat > "${layers}/local.toml" <<EOL
 launch = true


### PR DESCRIPTION
Also reduce image size to a more manageable size (850MiB vs. 2.9GiB)

Fixes #170 and part of the work for #172
