### PR TITLE
ci: include vcpkg in vcpkg cache hash

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,9 +19,14 @@ jobs:
       with:
         path: |
           ~/.cache/vcpkg
-        key: vcpkg-${{ runner.os }}-${{ github.job }}-${{ hashFiles('vcpkg.json') }}
+        key: |
+          vcpkg-${{ runner.os }}-${{ github.job }}-${{ hashFiles(
+              '/usr/local/share/vcpkg/**/vcpkg.json',
+              '/usr/local/share/vcpkg/**/CONTROL',
+              'vcpkg.json') }}
         restore-keys: |
           vcpkg-${{ runner.os }}-${{ github.job }}-
+          vcpkg-${{ runner.os }}-
     - name: configure
       run: >
         cmake -S . -B ${{runner.workspace}}/build -GNinja

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -19,9 +19,14 @@ jobs:
       with:
         path: |
           ~/.cache/vcpkg
-        key: vcpkg-${{ runner.os }}-${{ github.job }}-${{ hashFiles('vcpkg.json') }}
+        key: |
+          vcpkg-${{ runner.os }}-${{ github.job }}-${{ hashFiles(
+              '/usr/local/share/vcpkg/**/vcpkg.json',
+              '/usr/local/share/vcpkg/**/CONTROL',
+              'vcpkg.json') }}
         restore-keys: |
           vcpkg-${{ runner.os }}-${{ github.job }}-
+          vcpkg-${{ runner.os }}-
     - name: configure
       run: >
         cmake -S . -B ${{runner.workspace}}/build -GNinja

--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -19,9 +19,14 @@ jobs:
         with:
           path: |
             ~/.cache/vcpkg
-          key: vcpkg-${{ runner.os }}-${{ github.job }}-${{ hashFiles('vcpkg.json') }}
+          key: |
+            vcpkg-${{ runner.os }}-${{ github.job }}-${{ hashFiles(
+                '/usr/local/share/vcpkg/**/vcpkg.json',
+                '/usr/local/share/vcpkg/**/CONTROL',
+                'vcpkg.json') }}
           restore-keys: |
             vcpkg-${{ runner.os }}-${{ github.job }}-
+            vcpkg-${{ runner.os }}-
       - name: configure
         run: >
           cmake -S . -B ${{runner.workspace}}/build -GNinja -DBUILD_TESTING=OFF

--- a/.github/workflows/sanitize.yaml
+++ b/.github/workflows/sanitize.yaml
@@ -25,9 +25,15 @@ jobs:
         with:
           path: |
             ~/.cache/vcpkg
-          key: vcpkg-${{ runner.os }}-${{ github.job }}-${{ matrix.sanitizer }}-${{ hashFiles('vcpkg.json') }}
+          key: |
+            vcpkg-${{ runner.os }}-${{ github.job }}-${{ hashFiles(
+                '/usr/local/share/vcpkg/**/vcpkg.json',
+                '/usr/local/share/vcpkg/**/CONTROL',
+                'vcpkg.json') }}
           restore-keys: |
             vcpkg-${{ runner.os }}-${{ github.job }}-${{ matrix.sanitizer }}-
+            vcpkg-${{ runner.os }}-${{ github.job }}-
+            vcpkg-${{ runner.os }}-
       - name: -fsanitize=${{matrix.sanitizer}} / configure
         run: >
           cmake -S . -B ${{runner.workspace}}/build -GNinja

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -17,9 +17,14 @@ jobs:
         with:
           path: |
             ~/.cache/vcpkg
-          key: vcpkg-${{ runner.os }}-${{ github.job }}-${{ hashFiles('vcpkg.json') }}
+          key: |
+            vcpkg-${{ runner.os }}-${{ github.job }}-${{ hashFiles(
+                '/usr/local/share/vcpkg/**/vcpkg.json',
+                '/usr/local/share/vcpkg/**/CONTROL',
+                'vcpkg.json') }}
           restore-keys: |
             vcpkg-${{ runner.os }}-${{ github.job }}-
+            vcpkg-${{ runner.os }}-
       - name: configure
         run: >
           cmake -S . -B ${{runner.workspace}}/build

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "functions-framework-cpp-dev",
-  "version-string": "0.0.1-dev",
-  "port-version": 1,
+  "version-string": "0.1.0-dev",
+  "port-version": 3,
   "homepage": "https://github.com/GoogleCloudPlatform/functions-framework-cpp/",
   "description": "Functions Framework for C++ -- Development",
   "dependencies": [


### PR DESCRIPTION
It seems that the builders for GitHub actions get updated from time to
time. With a new vcpkg binary all the existing vcpkg binary caches
become invalid, but GitHub actions did not know that, and keeps trying
to use it.

Also, we can share the vcpkg cache across builds, so let's do that.