### PR TITLE
refactor: use libcurl in HTTP testing examples

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -17,7 +17,6 @@
 find_package(storage_client REQUIRED)
 find_package(pubsub_client REQUIRED)
 find_package(fmt REQUIRED)
-find_package(Boost REQUIRED COMPONENTS filesystem)
 
 add_library(
     functions_framework_examples # cmake-format: sort
@@ -67,8 +66,7 @@ if (BUILD_TESTING)
         target_link_libraries(
             ${target}
             PRIVATE functions_framework_examples googleapis_functions_framework
-                    Boost::filesystem GTest::gmock_main GTest::gmock
-                    GTest::gtest)
+                    GTest::gmock_main GTest::gmock GTest::gtest)
         add_test(NAME ${target} COMMAND ${target})
     endforeach ()
 endif ()

--- a/examples/site/testing_http/CMakeLists.txt
+++ b/examples/site/testing_http/CMakeLists.txt
@@ -14,6 +14,9 @@
 # limitations under the License.
 # ~~~
 
+find_package(CURL CONFIG REQUIRED)
+find_package(Boost REQUIRED COMPONENTS filesystem)
+
 if (BUILD_TESTING)
     find_package(GTest CONFIG REQUIRED)
     set(googleapis_functions_framework_examples_unit_tests
@@ -31,8 +34,12 @@ if (BUILD_TESTING)
         add_executable("${target}" ${fname})
         target_link_libraries(
             ${target}
-            PRIVATE functions_framework_examples googleapis_functions_framework
-                    Boost::filesystem GTest::gmock_main GTest::gmock
+            PRIVATE functions_framework_examples
+                    googleapis_functions_framework
+                    CURL::libcurl
+                    Boost::filesystem
+                    GTest::gmock_main
+                    GTest::gmock
                     GTest::gtest)
     endforeach ()
 

--- a/examples/site/testing_http/http_integration_test.cc
+++ b/examples/site/testing_http/http_integration_test.cc
@@ -27,7 +27,7 @@ namespace bp = boost::process;
 namespace bfs = boost::filesystem;  // Boost.Process cannot use std::filesystem
 
 struct HttpResponse {
-  long code;
+  long code;  // NOLINT(google-runtime-int)
   std::string payload;
 };
 
@@ -71,7 +71,7 @@ TEST_F(HttpIntegrationTest, Basic) {
 }
 
 extern "C" size_t CurlOnWriteData(char* ptr, size_t size, size_t nmemb,
-                                         void* userdata) {
+                                  void* userdata) {
   auto* buffer = reinterpret_cast<std::string*>(userdata);
   buffer->append(ptr, size * nmemb);
   return size * nmemb;
@@ -91,7 +91,7 @@ HttpResponse HttpGet(std::string const& url, std::string const& payload) {
     }
   };
   auto get_response_code = [h = easy.get()]() {
-    long code;                        // NOLINT(google-runtime-int)
+    long code;  // NOLINT(google-runtime-int)
     auto e = curl_easy_getinfo(h, CURLINFO_RESPONSE_CODE, &code);
     if (e == CURLE_OK) {
       return code;


### PR DESCRIPTION
The next test will receive a URL, and we do not have reasonably easy
ways to parse a URL.  None that can be put in an example anyway: we
could use a regexp, but they are brutally complicated.