### PR TITLE
refactor: use Boost.Log in some examples

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -17,6 +17,7 @@
 find_package(storage_client REQUIRED)
 find_package(pubsub_client REQUIRED)
 find_package(fmt REQUIRED)
+find_package(Boost REQUIRED COMPONENTS log)
 
 add_library(
     functions_framework_examples # cmake-format: sort
@@ -66,7 +67,7 @@ if (BUILD_TESTING)
         target_link_libraries(
             ${target}
             PRIVATE functions_framework_examples googleapis_functions_framework
-                    GTest::gmock_main GTest::gmock GTest::gtest)
+                    Boost::log GTest::gmock_main GTest::gmock GTest::gtest)
         add_test(NAME ${target} COMMAND ${target})
     endforeach ()
 endif ()

--- a/examples/site/hello_world_pubsub/CMakeLists.txt
+++ b/examples/site/hello_world_pubsub/CMakeLists.txt
@@ -1,0 +1,22 @@
+# ~~~
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+find_package(googleapis_functions_framework)
+find_package(Boost REQUIRED COMPONENTS log)
+
+add_library(functions_framework_cpp_function hello_world_pubsub.cc)
+target_link_libraries(functions_framework_cpp_function
+                      googleapis-c++::functions_framework Boost::log)

--- a/examples/site/hello_world_pubsub/hello_world_pubsub.cc
+++ b/examples/site/hello_world_pubsub/hello_world_pubsub.cc
@@ -16,6 +16,7 @@
 #include <google/cloud/functions/cloud_event.h>
 #include <boost/archive/iterators/binary_from_base64.hpp>
 #include <boost/archive/iterators/transform_width.hpp>
+#include <boost/log/trivial.hpp>
 #include <nlohmann/json.hpp>
 #include <iostream>
 
@@ -31,7 +32,7 @@ void hello_world_pubsub(gcf::CloudEvent event) {  // NOLINT
   }
   auto const payload = nlohmann::json::parse(event.data().value_or("{}"));
   auto name = decode_base64(payload["message"]["data"].get<std::string>());
-  std::cerr << "Hello " << (name.empty() ? "World" : name) << "\n";
+  BOOST_LOG_TRIVIAL(info) << "Hello " << (name.empty() ? "World" : name);
 }
 // [END functions_helloworld_pubsub]
 

--- a/examples/site/hello_world_pubsub/vcpkg.json
+++ b/examples/site/hello_world_pubsub/vcpkg.json
@@ -2,6 +2,7 @@
   "name": "hello-world-pubsub",
   "version-string": "unversioned",
   "dependencies": [
+    "boost-log",
     "boost-serialization",
     "functions-framework-cpp",
     "nlohmann-json"

--- a/examples/site/hello_world_storage/CMakeLists.txt
+++ b/examples/site/hello_world_storage/CMakeLists.txt
@@ -1,0 +1,22 @@
+# ~~~
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+find_package(googleapis_functions_framework)
+find_package(Boost REQUIRED COMPONENTS log)
+
+add_library(functions_framework_cpp_function hello_world_storage.cc)
+target_link_libraries(functions_framework_cpp_function
+                      googleapis-c++::functions_framework Boost::log)

--- a/examples/site/hello_world_storage/hello_world_storage.cc
+++ b/examples/site/hello_world_storage/hello_world_storage.cc
@@ -16,6 +16,7 @@
 #include <google/cloud/functions/cloud_event.h>
 #include <boost/archive/iterators/binary_from_base64.hpp>
 #include <boost/archive/iterators/transform_width.hpp>
+#include <boost/log/trivial.hpp>
 #include <nlohmann/json.hpp>
 #include <iostream>
 
@@ -27,11 +28,13 @@ void hello_world_storage(gcf::CloudEvent event) {  // NOLINT
     return;
   }
   auto const payload = nlohmann::json::parse(event.data().value_or("{}"));
-  std::cout << "Event: " << event.id() << "\nEvent Type: " << event.type()
-            << "\nBucket: " << payload.value("bucket", "")
-            << "\nFile: " << payload.value("name", "")
-            << "\nMetageneration: " << payload.value("metageneration", "")
-            << "\nCreated: " << payload.value("timeCreated", "")
-            << "\nUpdated: " << payload.value("updated", "") << "\n";
+  BOOST_LOG_TRIVIAL(info) << "Event: " << event.id();
+  BOOST_LOG_TRIVIAL(info) << "Event Type: " << event.type();
+  BOOST_LOG_TRIVIAL(info) << "Bucket: " << payload.value("bucket", "");
+  BOOST_LOG_TRIVIAL(info) << "File: " << payload.value("name", "");
+  BOOST_LOG_TRIVIAL(info) << "Metageneration: "
+                          << payload.value("metageneration", "");
+  BOOST_LOG_TRIVIAL(info) << "Created: " << payload.value("timeCreated", "");
+  BOOST_LOG_TRIVIAL(info) << "Updated: " << payload.value("updated", "");
 }
 // [END functions_helloworld_storage]

--- a/examples/site/hello_world_storage/vcpkg.json
+++ b/examples/site/hello_world_storage/vcpkg.json
@@ -2,6 +2,7 @@
   "name": "hello-world-storage",
   "version-string": "unversioned",
   "dependencies": [
+    "boost-log",
     "boost-serialization",
     "functions-framework-cpp",
     "nlohmann-json"

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,13 +1,14 @@
 {
   "name": "functions-framework-cpp-dev",
   "version-string": "0.3.0-dev",
-  "port-version": 1,
+  "port-version": 2,
   "homepage": "https://github.com/GoogleCloudPlatform/functions-framework-cpp/",
   "description": "Functions Framework for C++ -- Development",
   "dependencies": [
     "abseil",
     "boost-beast",
     "boost-filesystem",
+    "boost-log",
     "boost-process",
     "boost-program-options",
     "boost-property-tree",


### PR DESCRIPTION
These examples will be used to create testing examples, i.e., show our
users how to write unit, integration, and system tests.  In those, we
will want to capture the log output.

Part of the work for #101 and #104 