### PR TITLE
chore: prepare for v0.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,19 @@
 # Changelog
 
-## v0.3.0 - TBD
+## v0.4.0 - TBD
 
-* Renamed package and targets to use `functions-framework-cpp` as
-  the project's prefix.
+## v0.3.0 - 2021-02
+
+* **BREAKING CHANGE:** Renamed package and targets to use
+  `functions-framework-cpp` as the project's prefix.
+
+* doc: clarify backwards compatibility guidelines (#204)
+* feat: implement storage_integration_test example (#198)
+* feat: implement pubsub_integration_test example (#195)
+* feat: implement storage_unit_test example (#196)
+* feat: implement pubsub_unit_test example (#194)
+* refactor: use Boost.Log in some examples (#192)
+* feat: implement http_system_test example (#193)
 
 ## v0.2.0 - 2021-01
 


### PR DESCRIPTION
I need to write "how-to" guides to use the functions framework.
These would be substantially easier if the framework was a
vcpkg port, and that requires a new release.
