### PR TITLE
ci: move builds to {{runner.temp}}

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,11 +29,11 @@ jobs:
           vcpkg-${{ runner.os }}-
     - name: configure
       run: >
-        cmake -S . -B ${{runner.workspace}}/build -GNinja
+        cmake -S . -B "${{runner.temp}}/build" -GNinja
         -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
         -DCMAKE_TOOLCHAIN_FILE=/usr/local/share/vcpkg/scripts/buildsystems/vcpkg.cmake
     - name: build
-      run: cmake --build ${{runner.workspace}}/build
+      run: cmake --build "${{runner.temp}}/build"
     - name: test
-      working-directory: ${{runner.workspace}}/build
+      working-directory: "${{runner.temp}}/build"
       run: ctest --output-on-failure --timeout=60s

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -29,15 +29,15 @@ jobs:
           vcpkg-${{ runner.os }}-
     - name: configure
       run: >
-        cmake -S . -B ${{runner.workspace}}/build -GNinja
+        cmake -S . -B "${{runner.temp}}/build" -GNinja
         -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
         -DCMAKE_BUILD_TYPE=Debug
         -DCMAKE_CXX_FLAGS=--coverage
         -DCMAKE_TOOLCHAIN_FILE=/usr/local/share/vcpkg/scripts/buildsystems/vcpkg.cmake
     - name: build
-      run: cmake --build ${{runner.workspace}}/build
+      run: cmake --build "${{runner.temp}}/build"
     - name: test
-      working-directory: ${{runner.workspace}}/build
+      working-directory: "${{runner.temp}}/build"
       run: ctest --output-on-failure --timeout=60s
 
     - name: Setup Go
@@ -51,7 +51,7 @@ jobs:
         functionType: 'cloudevent'
         useBuildpacks: false
         validateMapping: false
-        cmd: '${{runner.workspace}}/build/google/cloud/functions/integration_tests/cloud_event_conformance'
+        cmd: '${{runner.temp}}/build/google/cloud/functions/integration_tests/cloud_event_conformance'
 
     - name: Run HTTP conformance tests
       uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.2
@@ -59,9 +59,9 @@ jobs:
         functionType: 'http'
         useBuildpacks: false
         validateMapping: false
-        cmd: '${{runner.workspace}}/build/google/cloud/functions/integration_tests/http_conformance'
+        cmd: '${{runner.temp}}/build/google/cloud/functions/integration_tests/http_conformance'
 
     - name: coverage-upload
-      working-directory: ${{runner.workspace}}
+      working-directory: "${{runner.temp}}"
       run: >
         /bin/bash <(curl -s https://codecov.io/bash) -X coveragepy -x /usr/bin/gcov

--- a/.github/workflows/sanitize.yaml
+++ b/.github/workflows/sanitize.yaml
@@ -38,16 +38,16 @@ jobs:
         # See https://github.com/grpc/grpc/pull/22325 for an explanation around the
         # -DGRPC_* flags.
         run: >
-          cmake -S . -B ${{runner.workspace}}/build -GNinja
+          cmake -S . -B "${{runner.temp}}/build" -GNinja
           -DCMAKE_CXX_COMPILER=clang++-10
           -DCMAKE_BUILD_TYPE=Debug
           -DCMAKE_CXX_FLAGS="-fsanitize=${{matrix.sanitizer}} -DGRPC_TSAN_SUPPRESSED -DGRPC_ASAN_SUPPRESSED"
           -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
           -DCMAKE_TOOLCHAIN_FILE=/usr/local/share/vcpkg/scripts/buildsystems/vcpkg.cmake
       - name: -fsanitize=${{matrix.sanitizer}} / build
-        run: cmake --build ${{runner.workspace}}/build
+        run: cmake --build "${{runner.temp}}/build"
       - name: -fsanitize=${{matrix.sanitizer}} / test
-        working-directory: ${{runner.workspace}}/build
+        working-directory: "${{runner.temp}}/build"
         env:
           ASAN_OPTIONS: detect_leaks=1:color=always
           LSAN_OPTIONS: report_objects=1

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -27,7 +27,7 @@ jobs:
             vcpkg-${{ runner.os }}-
       - name: configure
         run: >
-          cmake -S . -B ${{runner.workspace}}/build
+          cmake -S . -B "${{runner.temp}}/build"
           -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
           -DCMAKE_TOOLCHAIN_FILE=/usr/local/share/vcpkg/scripts/buildsystems/vcpkg.cmake
       - name: install clang-tidy
@@ -36,7 +36,7 @@ jobs:
         run: >
           git ls-files -z |
           grep -zE '\.cc$' |
-          xargs --verbose -P 2 -n 1 -0 clang-tidy-10 -p=${{runner.workspace}}/build
+          xargs --verbose -P 2 -n 1 -0 clang-tidy-10 -p="${{runner.temp}}/build"
 
   clang-format:
     name: clang-format


### PR DESCRIPTION
Move all the build output to `${{runner.temp}}`, seems wrong to dump
artifacts in the workspace where the code is. Specially since they give
us a nice directory to put this stuff into.