### PR TITLE
ci: fix CI script problems

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,7 +34,6 @@ jobs:
           vcpkg-${{ env.vcpkg_SHA }}-${{ runner.os }}-${{ github.job }}-${{ hashFiles('vcpkg.json') }}
         restore-keys: |
           vcpkg-${{ env.vcpkg_SHA }}-${{ runner.os }}-${{ github.job }}-
-          vcpkg-${{ env.vcpkg_SHA }}-${{ runner.os }}-
     - name: boostrap-vcpkg
       run: ci/restore-vcpkg-from-cache.sh "${{runner.temp}}/vcpkg"
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,9 +31,9 @@ jobs:
           ~/.cache/vcpkg
           ~/.cache/bin
         key: |
-          vcpkg-${{ env.vcpkg_SHA }}-${{ runner.os }}-${{ github.job }}-${{ hashFiles('vcpkg.json') }}
+          vcpkg-${{ env.vcpkg_SHA }}-build-ubuntu-focal-${{ hashFiles('vcpkg.json') }}
         restore-keys: |
-          vcpkg-${{ env.vcpkg_SHA }}-${{ runner.os }}-${{ github.job }}-
+          vcpkg-${{ env.vcpkg_SHA }}-build-ubuntu-focal-
     - name: boostrap-vcpkg
       run: ci/restore-vcpkg-from-cache.sh "${{runner.temp}}/vcpkg"
 

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -34,7 +34,6 @@ jobs:
           vcpkg-${{ env.vcpkg_SHA }}-${{ runner.os }}-${{ github.job }}-${{ hashFiles('vcpkg.json') }}
         restore-keys: |
           vcpkg-${{ env.vcpkg_SHA }}-${{ runner.os }}-${{ github.job }}-
-          vcpkg-${{ env.vcpkg_SHA }}-${{ runner.os }}-
     - name: boostrap-vcpkg
       run: ci/restore-vcpkg-from-cache.sh "${{runner.temp}}/vcpkg"
     - name: configure
@@ -72,6 +71,6 @@ jobs:
         cmd: '${{runner.temp}}/build/google/cloud/functions/integration_tests/http_conformance'
 
     - name: coverage-upload
-      working-directory: "${{runner.temp}}"
+      working-directory: "${{github.workspace}}"
       run: >
-        /bin/bash <(curl -s https://codecov.io/bash) -X coveragepy -x /usr/bin/gcov
+        /bin/bash <(curl -s https://codecov.io/bash) -X coveragepy -x /usr/bin/gcov -s "${{runner.temp}}"

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -60,7 +60,7 @@ jobs:
         functionType: 'cloudevent'
         useBuildpacks: false
         validateMapping: false
-        cmd: '${{runner.temp}}/build/google/cloud/functions/integration_tests/cloud_event_conformance'
+        cmd: '${{github.workspace}}/.build/google/cloud/functions/integration_tests/cloud_event_conformance'
 
     - name: Run HTTP conformance tests
       uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.2
@@ -68,7 +68,7 @@ jobs:
         functionType: 'http'
         useBuildpacks: false
         validateMapping: false
-        cmd: '${{runner.temp}}/build/google/cloud/functions/integration_tests/http_conformance'
+        cmd: '${{github.workspace}}/.build/google/cloud/functions/integration_tests/http_conformance'
 
     - name: coverage-upload
       working-directory: "${{github.workspace}}"

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -38,15 +38,15 @@ jobs:
       run: ci/restore-vcpkg-from-cache.sh "${{runner.temp}}/vcpkg"
     - name: configure
       run: >
-        cmake -S . -B "${{runner.temp}}/build" -GNinja
+        cmake -S . -B .build -GNinja
         -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
         -DCMAKE_BUILD_TYPE=Debug
         -DCMAKE_CXX_FLAGS=--coverage
         -DCMAKE_TOOLCHAIN_FILE="${{runner.temp}}/vcpkg/scripts/buildsystems/vcpkg.cmake"
     - name: build
-      run: cmake --build "${{runner.temp}}/build"
+      run: cmake --build .build
     - name: test
-      working-directory: "${{runner.temp}}/build"
+      working-directory: "${{github.workspace}}/.build"
       run: ctest --output-on-failure --timeout=60s
 
     - name: Setup Go
@@ -73,4 +73,4 @@ jobs:
     - name: coverage-upload
       working-directory: "${{github.workspace}}"
       run: >
-        /bin/bash <(curl -s https://codecov.io/bash) -X coveragepy -x /usr/bin/gcov -s "${{runner.temp}}"
+        /bin/bash <(curl -s https://codecov.io/bash) -X coveragepy -x /usr/bin/gcov

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -31,9 +31,9 @@ jobs:
           ~/.cache/vcpkg
           ~/.cache/bin
         key: |
-          vcpkg-${{ env.vcpkg_SHA }}-${{ runner.os }}-${{ github.job }}-${{ hashFiles('vcpkg.json') }}
+          vcpkg-${{ env.vcpkg_SHA }}-coverage-${{ hashFiles('vcpkg.json') }}
         restore-keys: |
-          vcpkg-${{ env.vcpkg_SHA }}-${{ runner.os }}-${{ github.job }}-
+          vcpkg-${{ env.vcpkg_SHA }}-coverage-
     - name: boostrap-vcpkg
       run: ci/restore-vcpkg-from-cache.sh "${{runner.temp}}/vcpkg"
     - name: configure

--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -34,7 +34,6 @@ jobs:
             vcpkg-${{ env.vcpkg_SHA }}-${{ runner.os }}-${{ github.job }}-${{ hashFiles('vcpkg.json') }}
           restore-keys: |
             vcpkg-${{ env.vcpkg_SHA }}-${{ runner.os }}-${{ github.job }}-
-            vcpkg-${{ env.vcpkg_SHA }}-${{ runner.os }}-
       - name: boostrap-vcpkg
         run: ci/restore-vcpkg-from-cache.sh "${{runner.temp}}/vcpkg"
       - name: configure

--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -9,7 +9,7 @@ env:
   vcpkg_SHA: "5214a247018b3bf2d793cea188ea2f2c150daddd"
 
 jobs:
-  build-ubuntu-focal:
+  static:
     name: ubuntu-20.04
     runs-on: ubuntu-20.04
     steps:
@@ -31,9 +31,9 @@ jobs:
             ~/.cache/vcpkg
             ~/.cache/bin
           key: |
-            vcpkg-${{ env.vcpkg_SHA }}-${{ runner.os }}-${{ github.job }}-${{ hashFiles('vcpkg.json') }}
+            vcpkg-${{ env.vcpkg_SHA }}-install-static-${{ hashFiles('vcpkg.json') }}
           restore-keys: |
-            vcpkg-${{ env.vcpkg_SHA }}-${{ runner.os }}-${{ github.job }}-
+            vcpkg-${{ env.vcpkg_SHA }}-install-static-
       - name: boostrap-vcpkg
         run: ci/restore-vcpkg-from-cache.sh "${{runner.temp}}/vcpkg"
       - name: configure
@@ -65,7 +65,7 @@ jobs:
       - name: test-build
         run: cmake --build ${{runner.temp}}/quickstart/build
 
-  build-ubuntu-focal-shared:
+  shared:
     name: ubuntu-20.04-shared
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/sanitize.yaml
+++ b/.github/workflows/sanitize.yaml
@@ -37,9 +37,9 @@ jobs:
             ~/.cache/vcpkg
             ~/.cache/bin
           key: |
-            vcpkg-${{ env.vcpkg_SHA }}-${{ runner.os }}-${{ matrix.sanitize }}-${{ hashFiles('vcpkg.json') }}
+            vcpkg-${{ env.vcpkg_SHA }}-sanitize-${{ matrix.sanitize }}-${{ hashFiles('vcpkg.json') }}
           restore-keys: |
-            vcpkg-${{ env.vcpkg_SHA }}-${{ runner.os }}-${{ matrix.sanitize }}-
+            vcpkg-${{ env.vcpkg_SHA }}-sanitize-${{ matrix.sanitize }}-
       - name: boostrap-vcpkg
         run: ci/restore-vcpkg-from-cache.sh "${{runner.temp}}/vcpkg"
       - name: -fsanitize=${{matrix.sanitizer}} / configure

--- a/.github/workflows/sanitize.yaml
+++ b/.github/workflows/sanitize.yaml
@@ -37,9 +37,9 @@ jobs:
             ~/.cache/vcpkg
             ~/.cache/bin
           key: |
-            vcpkg-${{ env.vcpkg_SHA }}-sanitize-${{ matrix.sanitize }}-${{ hashFiles('vcpkg.json') }}
+            vcpkg-${{ env.vcpkg_SHA }}-sanitize-${{ matrix.sanitizer }}-${{ hashFiles('vcpkg.json') }}
           restore-keys: |
-            vcpkg-${{ env.vcpkg_SHA }}-sanitize-${{ matrix.sanitize }}-
+            vcpkg-${{ env.vcpkg_SHA }}-sanitize-${{ matrix.sanitizer }}-
       - name: boostrap-vcpkg
         run: ci/restore-vcpkg-from-cache.sh "${{runner.temp}}/vcpkg"
       - name: -fsanitize=${{matrix.sanitizer}} / configure

--- a/.github/workflows/sanitize.yaml
+++ b/.github/workflows/sanitize.yaml
@@ -37,10 +37,9 @@ jobs:
             ~/.cache/vcpkg
             ~/.cache/bin
           key: |
-            vcpkg-${{ env.vcpkg_SHA }}-${{ runner.os }}-${{ github.job }}-${{ hashFiles('vcpkg.json') }}
+            vcpkg-${{ env.vcpkg_SHA }}-${{ runner.os }}-${{ matrix.sanitize }}-${{ hashFiles('vcpkg.json') }}
           restore-keys: |
-            vcpkg-${{ env.vcpkg_SHA }}-${{ runner.os }}-${{ github.job }}-
-            vcpkg-${{ env.vcpkg_SHA }}-${{ runner.os }}-
+            vcpkg-${{ env.vcpkg_SHA }}-${{ runner.os }}-${{ matrix.sanitize }}-
       - name: boostrap-vcpkg
         run: ci/restore-vcpkg-from-cache.sh "${{runner.temp}}/vcpkg"
       - name: -fsanitize=${{matrix.sanitizer}} / configure
@@ -49,6 +48,7 @@ jobs:
         run: >
           cmake -S . -B "${{runner.temp}}/build" -GNinja
           -DCMAKE_CXX_COMPILER=clang++-10
+          -DCMAKE_C_COMPILER=clang-10
           -DCMAKE_BUILD_TYPE=Debug
           -DCMAKE_CXX_FLAGS="-fsanitize=${{matrix.sanitizer}} -DGRPC_TSAN_SUPPRESSED -DGRPC_ASAN_SUPPRESSED"
           -DCMAKE_EXPORT_COMPILE_COMMANDS=ON

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -13,6 +13,8 @@ jobs:
     name: clang-tidy
     runs-on: ubuntu-20.04
     steps:
+      - name: install ninja
+        run: sudo apt install ninja-build
       - uses: actions/checkout@v2
       - name: clone-vcpkg
         working-directory: "${{runner.temp}}"
@@ -32,7 +34,6 @@ jobs:
             vcpkg-${{ env.vcpkg_SHA }}-${{ runner.os }}-${{ github.job }}-${{ hashFiles('vcpkg.json') }}
           restore-keys: |
             vcpkg-${{ env.vcpkg_SHA }}-${{ runner.os }}-${{ github.job }}-
-            vcpkg-${{ env.vcpkg_SHA }}-${{ runner.os }}-
       - name: boostrap-vcpkg
         run: ci/restore-vcpkg-from-cache.sh "${{runner.temp}}/vcpkg"
       - name: configure

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -31,9 +31,9 @@ jobs:
             ~/.cache/vcpkg
             ~/.cache/bin
           key: |
-            vcpkg-${{ env.vcpkg_SHA }}-${{ runner.os }}-${{ github.job }}-${{ hashFiles('vcpkg.json') }}
+            vcpkg-${{ env.vcpkg_SHA }}-style-clang-tidy-${{ hashFiles('vcpkg.json') }}
           restore-keys: |
-            vcpkg-${{ env.vcpkg_SHA }}-${{ runner.os }}-${{ github.job }}-
+            vcpkg-${{ env.vcpkg_SHA }}-style-clang-tidy-
       - name: boostrap-vcpkg
         run: ci/restore-vcpkg-from-cache.sh "${{runner.temp}}/vcpkg"
       - name: configure

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
+      - name: clone-vcpkg
         working-directory: "${{runner.temp}}"
         run: >
           mkdir -p vcpkg &&

--- a/ci/restore-vcpkg-from-cache.sh
+++ b/ci/restore-vcpkg-from-cache.sh
@@ -23,7 +23,7 @@ fi
 readonly VCPKG_ROOT="${1}"
 
 if [[ -x "${HOME}/.cache/bin/vcpkg" ]]; then
-  cp "${HOME}/.cache/bin/vcpkg" .
+  cp "${HOME}/.cache/bin/vcpkg" "${VCPKG_ROOT}/vcpkg"
 else
   (cd "${VCPKG_ROOT}"  && ./bootstrap-vcpkg.sh -useSystemBinaries)
   mkdir -p "${HOME}/.cache/bin"


### PR DESCRIPTION
One of the workflow definition files had a syntax error. Workflows with such problems
are ignored in PRs (unless they are a required action), so we missed it.

I was too aggressive sharing the cache files, resulting in unusable caches, the cache
would be downloaded, vcpkg would not be able to use any of the contents, and then
the cache is not refreshed because the key matches perfectly.

The coverage build was not uploading any useful data, it needs to run from the directory
where the source lives, and receive the binary directory as an arguments.
