### PR TITLE
feat: implement pubsub_system_test example

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@
 [fmt-gh]: https://github.com/fmtlib/fmt
 [buildpacks]: https://github.com/GoogleCloudPlatform/buildpacks
 [CloudEvents]: https://cloudevents.io/
-[C++ quickstart]: google/cloud/functions/quickstart/README.md
 [docs]: docs
 [examples]: examples
 [examples/hello_world/hello_world.cc]: examples/hello_world/hello_world.cc

--- a/examples/site/hello_world_pubsub/hello_world_pubsub.cc
+++ b/examples/site/hello_world_pubsub/hello_world_pubsub.cc
@@ -1,5 +1,4 @@
 // Copyright 2020 Google LLC
-
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/site/hello_world_pubsub/hello_world_pubsub.cc
+++ b/examples/site/hello_world_pubsub/hello_world_pubsub.cc
@@ -1,4 +1,5 @@
 // Copyright 2020 Google LLC
+
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/examples/site/testing_pubsub/CMakeLists.txt
+++ b/examples/site/testing_pubsub/CMakeLists.txt
@@ -16,12 +16,12 @@
 
 if (BUILD_TESTING)
     find_package(GTest CONFIG REQUIRED)
+    find_package(fmt CONFIG REQUIRED)
+    find_package(google_cloud_cpp_pubsub REQUIRED)
+
     set(functions_framework_cpp_examples_unit_tests
         # cmake-format: sort
         pubsub_integration_test.cc pubsub_unit_test.cc)
-
-    set(functions_framework_cpp_examples_programs # cmake-format: sort
-                                                  pubsub_integration_server.cc)
 
     foreach (fname ${functions_framework_cpp_examples_unit_tests})
         string(REPLACE "/" "_" target "${fname}")
@@ -39,14 +39,15 @@ if (BUILD_TESTING)
         add_test(NAME ${target} COMMAND ${target})
     endforeach ()
 
-    foreach (fname ${functions_framework_cpp_examples_programs})
-        string(REPLACE "/" "_" target "${fname}")
-        string(REPLACE ".cc" "" target "${target}")
-        add_executable("${target}" ${fname})
-        target_link_libraries(
-            ${target}
-            PRIVATE functions_framework_examples
-                    functions-framework-cpp::framework Boost::filesystem
-                    Boost::log)
-    endforeach ()
+    add_executable(pubsub_integration_server pubsub_integration_server.cc)
+    target_link_libraries(
+        pubsub_integration_server
+        PRIVATE functions_framework_examples functions-framework-cpp::framework
+                Boost::filesystem Boost::log)
+
+    add_executable(pubsub_system_test pubsub_system_test.cc)
+    target_link_libraries(
+        pubsub_system_test
+        PRIVATE google-cloud-cpp::pubsub fmt::fmt Boost::log
+                GTest::gmock_main GTest::gmock GTest::gtest)
 endif ()

--- a/examples/site/testing_pubsub/CMakeLists.txt
+++ b/examples/site/testing_pubsub/CMakeLists.txt
@@ -47,7 +47,6 @@ if (BUILD_TESTING)
 
     add_executable(pubsub_system_test pubsub_system_test.cc)
     target_link_libraries(
-        pubsub_system_test
-        PRIVATE google-cloud-cpp::pubsub fmt::fmt Boost::log
-                GTest::gmock_main GTest::gmock GTest::gtest)
+        pubsub_system_test PRIVATE google-cloud-cpp::pubsub fmt::fmt Boost::log
+                                   GTest::gmock_main GTest::gmock GTest::gtest)
 endif ()

--- a/examples/site/testing_pubsub/README.md
+++ b/examples/site/testing_pubsub/README.md
@@ -6,7 +6,8 @@
 [pubsub_unit_test.cc]: pubsub_unit_test.cc
 [pubsub_integration_server.cc]: pubsub_integration_server.cc
 [pubsub_integration_test.cc]: pubsub_integration_test.cc
-[quickstart-guide]: /google/cloud/functions/quickstart/README.md
+[quickstart-guide]: /examples/site/howto_local_development/README.md
+[container-guide]: /examples/site/howto_create_container/README.md
 [pubsub-quickstart]: https://cloud.google.com/pubsub/docs/quickstart-console
 
 Event-driven functions do not return values, their only observable behavior are
@@ -69,7 +70,7 @@ This guide assumes that you have:
   ``` 
 * you need to create a [buildpacks builder][buildpacks] that can create
   Docker images from your C++ functions, see the
-  [quickstart guide][quickstart-guide] for more information,
+  [Howto Guide][container-guide] for more information,
 
 ```shell
 pack build pack build \

--- a/examples/site/testing_pubsub/README.md
+++ b/examples/site/testing_pubsub/README.md
@@ -1,0 +1,115 @@
+# How-to Guide: Testing Event-driven Functions (Pub/Sub triggered)
+
+[buildpacks]: https://buildpacks.io
+[boost-log-gh]: https://github.com/boostorg/log
+[/examples/site/hello_world_pubsub/hello_world_pubsub.cc]: /examples/site/hello_world_pubsub/hello_world_pubsub.cc
+[pubsub_unit_test.cc]: pubsub_unit_test.cc
+[pubsub_integration_server.cc]: pubsub_integration_server.cc
+[pubsub_integration_test.cc]: pubsub_integration_test.cc
+[quickstart-guide]: /google/cloud/functions/quickstart/README.md
+[pubsub-quickstart]: https://cloud.google.com/pubsub/docs/quickstart-console
+
+Event-driven functions do not return values, their only observable behavior are
+side-effects. All tests, therefore, are looking at the side-effects of these
+functions. Depending on where the function is deployed this might be more or
+less involved.
+
+## Function under Test
+
+We will use this function throughput this guide:
+
+[/examples/site/hello_world_pubsub/hello_world_pubsub.cc]
+```cc
+namespace gcf = ::google::cloud::functions;
+
+// Use Boost.Archive to decode Pub/Sub message payload
+std::string decode_base64(std::string const& base64);
+
+void hello_world_pubsub(gcf::CloudEvent event) {  // NOLINT
+  if (event.data_content_type().value_or("") != "application/json") {
+    std::cerr << "Error: expected application/json data\n";
+    return;
+  }
+  auto const payload = nlohmann::json::parse(event.data().value_or("{}"));
+  auto name = decode_base64(payload["message"]["data"].get<std::string>());
+  BOOST_LOG_TRIVIAL(info) << "Hello " << (name.empty() ? "World" : name);
+}
+```
+
+## Writing a Unit Test
+
+This function uses the [Boost.Log][boost-log-gh] library to facilitate unit
+testing. Logging can be captured and examined using the usual testing
+assertions, see [pubsub_unit_test.cc] for more details.
+
+## Writing an Integration Test
+
+To write an integration test we first create a local server to run the
+function, as shown in [pubsub_integration_server.cc], then we launch this
+server from within the [integration test][pubsub_integration_test.cc] and
+examine its result.
+
+## Writing a System Test
+
+### Pre-requisites
+
+This guide assumes that you have:
+
+* a working Pub/Sub topic, see the [Pub/Sub quickstart guide][pubsub-quickstart]
+  for more information,
+* set the `TOPIC_ID` shell variable to the id of this topic, e.g.
+  ```shell
+  TOPIC_ID=my-testing-topic
+  ```
+* as part of the Pub/Sub quickstart guide you would have identified a GCP
+  project to run your tests, set the `GOOGLE_CLOUD_PROJECT` shell variable
+  to the id of his project, for example:
+  ```shell
+  GOOGLE_CLOUD_PROJECT=my-testing-project
+  ``` 
+* you need to create a [buildpacks builder][buildpacks] that can create
+  Docker images from your C++ functions, see the
+  [quickstart guide][quickstart-guide] for more information,
+
+```shell
+pack build pack build \
+    --builder gcf-cpp-builder:bionic \
+    --env "FUNCTION_SIGNATURE_TYPE=cloudevent" \
+    --env "TARGET_FUNCTION=hello_world_pubsub" \
+    --path "examples/site/hello_world_pubsub" \
+    "gcr.io/${GOOGLE_CLOUD_PROJECT}/hello_world_pubsub"
+```
+
+Deploy this function to Cloud Run:
+
+```shell
+docker push "gcr.io/${GOOGLE_CLOUD_PROJECT}/hello_world_pubsub"
+gcloud run deploy gcf-hello-world-pubsub \
+    --project="${GOOGLE_CLOUD_PROJECT}" \
+    --image="gcr.io/${GOOGLE_CLOUD_PROJECT}/gcf-hello-world-pubsub:latest" \
+    --region="us-central1" \
+    --platform="managed" \
+    --allow-unauthenticated
+```
+
+Setup a Pub/Sub trigger:
+
+```shell
+gcloud beta eventarc triggers create gcf-hello-world-pubsub-trigger \
+    --project="${GOOGLE_CLOUD_PROJECT}" \
+    --location="us-central1" \
+    --destination-run-service="gcf-hello-world-pubsub" \
+    --destination-run-region="us-central1" \
+    --matching-criteria="type=google.cloud.pubsub.topic.v1.messagePublished" \
+    --transport-topic="${TOPIC_ID}"
+```
+
+Finally, you can run the system test, using environment variables to pass
+any configuration parameters:
+
+```shell
+env "GOOGLE_CLOUD_PROJECT=${GOOGLE_CLOUD_PROJECT}" \
+    "TOPIC_ID=${TOPIC_ID}" \
+    "SERVICE_ID=gcf-hello-world-pubsub" \
+    ./pubsub_system_test # use actual path to binary
+```

--- a/examples/site/testing_pubsub/README.md
+++ b/examples/site/testing_pubsub/README.md
@@ -25,7 +25,7 @@ namespace gcf = ::google::cloud::functions;
 // Use Boost.Archive to decode Pub/Sub message payload
 std::string decode_base64(std::string const& base64);
 
-void hello_world_pubsub(gcf::CloudEvent event) {  // NOLINT
+void hello_world_pubsub(gcf::CloudEvent event) {
   if (event.data_content_type().value_or("") != "application/json") {
     std::cerr << "Error: expected application/json data\n";
     return;

--- a/examples/site/testing_pubsub/pubsub_system_test.cc
+++ b/examples/site/testing_pubsub/pubsub_system_test.cc
@@ -45,8 +45,7 @@ class PubsubSystemTest : public ::testing::Test {
     // not exist.
     auto admin = pubsub::TopicAdminClient(pubsub::MakeTopicAdminConnection());
     topic_ = pubsub::Topic(project_id, topic_id);
-    auto topic_metadata =
-        admin.CreateTopic(pubsub::TopicBuilder(topic()));
+    auto topic_metadata = admin.CreateTopic(pubsub::TopicBuilder(topic()));
     // If we get an error other than kAlreadyExists, abort the test.
     ASSERT_THAT(topic_metadata.status().code(),
                 AnyOf(google::cloud::StatusCode::kOk,

--- a/examples/site/testing_pubsub/pubsub_system_test.cc
+++ b/examples/site/testing_pubsub/pubsub_system_test.cc
@@ -1,0 +1,116 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START functions_pubsub_system_test]
+#include <google/cloud/pubsub/publisher.h>
+#include <google/cloud/pubsub/topic_admin_client.h>
+#include <boost/process.hpp>
+#include <fmt/format.h>
+#include <gmock/gmock.h>
+#include <chrono>
+#include <string>
+#include <thread>
+
+namespace {
+
+namespace bp = ::boost::process;
+namespace pubsub = ::google::cloud::pubsub;
+using ::testing::AnyOf;
+using ::testing::HasSubstr;
+
+class PubsubSystemTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    // This test can only run if it is properly configured.
+    auto const* project_id = std::getenv("GOOGLE_CLOUD_PROJECT");
+    ASSERT_NE(project_id, nullptr);
+    auto const* topic_id = std::getenv("TOPIC_ID");
+    ASSERT_NE(topic_id, nullptr);
+    auto const* service_id = std::getenv("SERVICE_ID");
+    ASSERT_NE(service_id, nullptr);
+    service_id_ = service_id;
+
+    // Automatically setup the test environment, create the topic if it does
+    // not exist.
+    auto admin = pubsub::TopicAdminClient(pubsub::MakeTopicAdminConnection());
+    topic_ = pubsub::Topic(project_id, topic_id);
+    auto topic_metadata =
+        admin.CreateTopic(pubsub::TopicBuilder(topic()));
+    // If we get an error other than kAlreadyExists, abort the test.
+    ASSERT_THAT(topic_metadata.status().code(),
+                AnyOf(google::cloud::StatusCode::kOk,
+                      google::cloud::StatusCode::kAlreadyExists));
+  }
+
+  void TearDown() override {}
+
+  [[nodiscard]] pubsub::Topic const& topic() const { return topic_; }
+  [[nodiscard]] std::string const& service_id() const { return service_id_; }
+
+ private:
+  pubsub::Topic topic_ = pubsub::Topic("--invalid--", "--invalid--");
+  std::string service_id_;
+};
+
+TEST_F(PubsubSystemTest, Basic) {
+  struct TestCases {
+    std::string data;
+    std::string expected;
+  } cases[]{
+      {"C++", "Hello C++"},
+      {"World", "Hello World"},
+  };
+
+  auto publisher =
+      pubsub::Publisher(pubsub::MakePublisherConnection(topic(), {}));
+
+  for (auto const& test : cases) {
+    SCOPED_TRACE("Testing for " + test.expected);
+    auto id =
+        publisher.Publish(pubsub::MessageBuilder().SetData(test.data).Build());
+    publisher.Flush();
+    EXPECT_TRUE(id.get().ok());
+
+    std::vector<std::string> lines;
+    // It may take a few seconds for the logs to propagate, so try a few times.
+    using namespace std::chrono_literals;
+    for (auto delay : {1s, 2s, 4s, 8s, 16s}) {
+      bp::ipstream out;
+      auto constexpr kProject = "--project={}";
+      auto constexpr kLogFilter =
+          "resource.type=cloud_run_revision AND "
+          "resource.labels.service_name={} AND "
+          "logName:stdout";
+      auto reader = bp::child(bp::search_path("gcloud"), "logging", "read",
+                              fmt::format(kProject, topic().project_id()),
+                              fmt::format(kLogFilter, service_id()),
+                              "--format=value(textPayload)", "--limit=1",
+                              (bp::std_out & bp::std_err) > out);
+      reader.wait();
+      ASSERT_EQ(reader.exit_code(), 0);
+      for (std::string l; std::getline(out, l);) lines.push_back(std::move(l));
+      auto count = std::count_if(lines.begin(), lines.end(),
+                                 [s = test.expected](auto l) {
+                                   return l.find(s) != std::string::npos;
+                                 });
+      if (count != 0) break;
+      std::this_thread::sleep_for(delay);
+    }
+    EXPECT_THAT(lines, Contains(HasSubstr(test.expected)));
+  }
+}
+
+}  // namespace
+
+// [END functions_pubsub_system_test]


### PR DESCRIPTION
Adds an example showing how to perform system tests for Pub/Sub
triggered functions.

Fixes #103 