### PR TITLE
cleanup: support turning on -Wall and -Werror

### DIFF
--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -77,9 +77,9 @@ jobs:
             ~/.cache/vcpkg
             ~/.cache/bin
           key: |
-            vcpkg-${{ env.vcpkg_SHA }}-werror-${{ matrix.compiler.cc }}-${{ hashFiles('vcpkg.json') }}
+            vcpkg-${{ env.vcpkg_SHA }}-werror-${{ matrix.compiler.cxx }}-${{ hashFiles('vcpkg.json') }}
           restore-keys: |
-            vcpkg-${{ env.vcpkg_SHA }}-werror-${{ matrix.compiler.cc }}-
+            vcpkg-${{ env.vcpkg_SHA }}-werror-${{ matrix.compiler.cxx }}-
       - name: boostrap-vcpkg
         run: ci/restore-vcpkg-from-cache.sh "${{runner.temp}}/vcpkg"
       - name: compiler=${{matrix.sanitizer}} / configure
@@ -87,14 +87,14 @@ jobs:
           cmake -S . -B "${{runner.temp}}/build" -GNinja
           -DFUNCTIONS_FRAMEWORK_CPP_ENABLE_WERROR=ON
           -DCMAKE_CXX_COMPILER=${{matrix.compiler.cxx}}
-          -DCMAKE_C_COMPILER=${matrix.compiler.cc}}
+          -DCMAKE_C_COMPILER=${{matrix.compiler.cc}}
           -DCMAKE_BUILD_TYPE=Debug
           -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
           -DCMAKE_TOOLCHAIN_FILE="${{runner.temp}}/vcpkg/scripts/buildsystems/vcpkg.cmake"
 # TODO(coryan) - uncomment after warming up the cache
 #      - name: compiler=${{matrix.compiler.cxx}} / build
 #        run: cmake --build "${{runner.temp}}/build"
-#      - name: -fsanitize=${{matrix.compiler.cxx}} / test
+#      - name: compiler=${{matrix.compiler.cxx}} / test
 #        working-directory: "${{runner.temp}}/build"
 #        run: ctest --output-on-failure --timeout=60s
 

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -82,17 +82,16 @@ jobs:
             vcpkg-${{ env.vcpkg_SHA }}-werror-${{ matrix.compiler.cc }}-
       - name: boostrap-vcpkg
         run: ci/restore-vcpkg-from-cache.sh "${{runner.temp}}/vcpkg"
+      - name: compiler=${{matrix.sanitizer}} / configure
+        run: >
+          cmake -S . -B "${{runner.temp}}/build" -GNinja
+          -DFUNCTIONS_FRAMEWORK_CPP_ENABLE_WERROR=ON
+          -DCMAKE_CXX_COMPILER=${{matrix.compiler.cxx}}
+          -DCMAKE_C_COMPILER=${matrix.compiler.cc}}
+          -DCMAKE_BUILD_TYPE=Debug
+          -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+          -DCMAKE_TOOLCHAIN_FILE="${{runner.temp}}/vcpkg/scripts/buildsystems/vcpkg.cmake"
 # TODO(coryan) - uncomment after warming up the cache
-#      - name: compiler=${{matrix.sanitizer}} / configure
-#        # See https://github.com/grpc/grpc/pull/22325 for an explanation around the
-#        # -DGRPC_* flags.
-#        run: >
-#          cmake -S . -B "${{runner.temp}}/build" -GNinja
-#          -DCMAKE_CXX_COMPILER=${{matrix.compiler.cxx}}
-#          -DCMAKE_C_COMPILER=${matrix.compiler.cc}}
-#          -DCMAKE_BUILD_TYPE=Debug
-#          -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
-#          -DCMAKE_TOOLCHAIN_FILE="${{runner.temp}}/vcpkg/scripts/buildsystems/vcpkg.cmake"
 #      - name: compiler=${{matrix.compiler.cxx}} / build
 #        run: cmake --build "${{runner.temp}}/build"
 #      - name: -fsanitize=${{matrix.compiler.cxx}} / test

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -91,12 +91,11 @@ jobs:
           -DCMAKE_BUILD_TYPE=Debug
           -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
           -DCMAKE_TOOLCHAIN_FILE="${{runner.temp}}/vcpkg/scripts/buildsystems/vcpkg.cmake"
-# TODO(coryan) - uncomment after warming up the cache
-#      - name: compiler=${{matrix.compiler.cxx}} / build
-#        run: cmake --build "${{runner.temp}}/build"
-#      - name: compiler=${{matrix.compiler.cxx}} / test
-#        working-directory: "${{runner.temp}}/build"
-#        run: ctest --output-on-failure --timeout=60s
+      - name: compiler=${{matrix.compiler.cxx}} / build
+        run: cmake --build "${{runner.temp}}/build"
+      - name: compiler=${{matrix.compiler.cxx}} / test
+        working-directory: "${{runner.temp}}/build"
+        run: ctest --output-on-failure --timeout=60s
 
   clang-format:
     name: clang-format

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: install ninja
-        run: sudo apt install ninja-build
+        run: sudo apt install ninja-build clang-tidy-10
       - uses: actions/checkout@v2
       - name: clone-vcpkg
         working-directory: "${{runner.temp}}"
@@ -41,13 +41,63 @@ jobs:
           cmake -S . -B "${{runner.temp}}/build"
           -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
           -DCMAKE_TOOLCHAIN_FILE="${{runner.temp}}/vcpkg/scripts/buildsystems/vcpkg.cmake"
-      - name: install clang-tidy
-        run: sudo apt install clang-tidy-10
       - name: tidy
         run: >
           git ls-files -z |
           grep -zE '\.cc$' |
           xargs --verbose -P 2 -n 1 -0 clang-tidy-10 -p="${{runner.temp}}/build"
+
+  werror-build:
+    # Using a blank name produces better output on
+    # the web UI than any other alternative we tried.
+    name: " "
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        compiler: [
+          {"cxx": "clang++-10", "cc": "clang-10"},
+          {"cxx": "g++-10", "cc": "gcc-10" },
+        ]
+    steps:
+      - name: install ninja
+        run: sudo apt install ninja-build
+      - uses: actions/checkout@v2
+      - name: clone-vcpkg
+        working-directory: "${{runner.temp}}"
+        run: >
+          mkdir -p vcpkg &&
+          curl -sSL "https://github.com/microsoft/vcpkg/archive/${{env.vcpkg_SHA}}.tar.gz" |
+          tar -C vcpkg --strip-components=1 -zxf -
+      - name: cache-vcpkg
+        id: cache-vcpkg
+        uses: actions/cache@v2
+        with:
+          # Preserve the vcpkg binary *and* the vcpkg binary cache in the build cache
+          path: |
+            ~/.cache/vcpkg
+            ~/.cache/bin
+          key: |
+            vcpkg-${{ env.vcpkg_SHA }}-werror-${{ matrix.compiler.cc }}-${{ hashFiles('vcpkg.json') }}
+          restore-keys: |
+            vcpkg-${{ env.vcpkg_SHA }}-werror-${{ matrix.compiler.cc }}-
+      - name: boostrap-vcpkg
+        run: ci/restore-vcpkg-from-cache.sh "${{runner.temp}}/vcpkg"
+# TODO(coryan) - uncomment after warming up the cache
+#      - name: compiler=${{matrix.sanitizer}} / configure
+#        # See https://github.com/grpc/grpc/pull/22325 for an explanation around the
+#        # -DGRPC_* flags.
+#        run: >
+#          cmake -S . -B "${{runner.temp}}/build" -GNinja
+#          -DCMAKE_CXX_COMPILER=${{matrix.compiler.cxx}}
+#          -DCMAKE_C_COMPILER=${matrix.compiler.cc}}
+#          -DCMAKE_BUILD_TYPE=Debug
+#          -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+#          -DCMAKE_TOOLCHAIN_FILE="${{runner.temp}}/vcpkg/scripts/buildsystems/vcpkg.cmake"
+#      - name: compiler=${{matrix.compiler.cxx}} / build
+#        run: cmake --build "${{runner.temp}}/build"
+#      - name: -fsanitize=${{matrix.compiler.cxx}} / test
+#        working-directory: "${{runner.temp}}/build"
+#        run: ctest --output-on-failure --timeout=60s
 
   clang-format:
     name: clang-format

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
 include(CTest)
+include(FunctionsFrameworkCppHelpers)
 add_subdirectory(google/cloud/functions)
 
 if (BUILD_TESTING)

--- a/cmake/FunctionsFrameworkCppHelpers.cmake
+++ b/cmake/FunctionsFrameworkCppHelpers.cmake
@@ -1,0 +1,69 @@
+# ~~~
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+option(FUNCTIONS_FRAMEWORK_CPP_ENABLE_WERROR
+       "If set, compiles the framework with -Werror and /WX (MSVC)." OFF)
+mark_as_advanced(FUNCTIONS_FRAMEWORK_CPP_ENABLE_WERROR)
+
+# Find out what flags turn on all available warnings and turn those warnings
+# into errors.
+include(CheckCXXCompilerFlag)
+check_cxx_compiler_flag(-Wall FUNCTIONS_FRAMEWORK_CPP_COMPILER_SUPPORTS_WALL)
+check_cxx_compiler_flag(-Wextra
+                        FUNCTIONS_FRAMEWORK_CPP_COMPILER_SUPPORTS_WEXTRA)
+check_cxx_compiler_flag(-Wconversion
+                        FUNCTIONS_FRAMEWORK_CPP_COMPILER_SUPPORTS_WCONVERSION)
+check_cxx_compiler_flag(
+    -Wno-sign-conversion
+    FUNCTIONS_FRAMEWORK_CPP_COMPILER_SUPPORTS_WNO_SIGN_CONVERSION)
+check_cxx_compiler_flag(-Werror
+                        FUNCTIONS_FRAMEWORK_CPP_COMPILER_SUPPORTS_WERROR)
+
+function (functions_framework_cpp_add_common_options target)
+    if (MSVC)
+        target_compile_options(${target} PRIVATE "/W3")
+        if (FUNCTIONS_FRAMEWORK_CPP_ENABLE_WERROR)
+            target_compile_options(${target} PRIVATE "/WX")
+        endif ()
+        target_compile_options(${target} PRIVATE "/experimental:external")
+        target_compile_options(${target} PRIVATE "/external:W0")
+        target_compile_options(${target} PRIVATE "/external:anglebrackets")
+        target_compile_definitions("${target}" PRIVATE "_WIN32_WINNT=0x0601")
+        return()
+    endif ()
+    if (FUNCTIONS_FRAMEWORK_CPP_COMPILER_SUPPORTS_WALL)
+        target_compile_options(${target} PRIVATE "-Wall")
+    endif ()
+    if (FUNCTIONS_FRAMEWORK_CPP_COMPILER_SUPPORTS_WEXTRA)
+        target_compile_options(${target} PRIVATE "-Wextra")
+    endif ()
+    if (FUNCTIONS_FRAMEWORK_CPP_COMPILER_SUPPORTS_WCONVERSION)
+        target_compile_options(${target} PRIVATE "-Wconversion")
+    endif ()
+    if (FUNCTIONS_FRAMEWORK_CPP_COMPILER_SUPPORTS_WNO_SIGN_CONVERSION)
+        target_compile_options(${target} PRIVATE "-Wno-sign-conversion")
+    endif ()
+    if (FUNCTIONS_FRAMEWORK_CPP_COMPILER_SUPPORTS_WERROR
+        AND FUNCTIONS_FRAMEWORK_CPP_ENABLE_WERROR)
+        target_compile_options(${target} PRIVATE "-Werror")
+    endif ()
+    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU"
+        AND "${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS 5.0)
+        # With GCC 4.x this warning is too noisy to be useful.
+        target_compile_options(${target}
+                               PRIVATE "-Wno-missing-field-initializers")
+    endif ()
+endfunction ()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -50,6 +50,7 @@ add_library(
     site/tips_lazy_globals/tips_lazy_globals.cc
     site/tips_retry/tips_retry.cc
     site/tips_scopes/tips_scopes.cc)
+functions_framework_cpp_add_common_options(functions_framework_examples)
 target_link_libraries(
     functions_framework_examples fmt::fmt functions-framework-cpp::framework
     google-cloud-cpp::pubsub google-cloud-cpp::storage)
@@ -64,6 +65,7 @@ if (BUILD_TESTING)
         string(REPLACE "/" "_" target "${fname}")
         string(REPLACE ".cc" "" target "${target}")
         add_executable("${target}" ${fname})
+        functions_framework_cpp_add_common_options(${target})
         target_link_libraries(
             ${target}
             PRIVATE functions_framework_examples

--- a/examples/site/testing_http/CMakeLists.txt
+++ b/examples/site/testing_http/CMakeLists.txt
@@ -31,6 +31,7 @@ if (BUILD_TESTING)
         string(REPLACE "/" "_" target "${fname}")
         string(REPLACE ".cc" "" target "${target}")
         add_executable("${target}" ${fname})
+        functions_framework_cpp_add_common_options(${target})
         target_link_libraries(
             ${target}
             PRIVATE functions_framework_examples
@@ -45,6 +46,7 @@ if (BUILD_TESTING)
     foreach (fname ${functions_framework_cpp_examples_unit_tests})
         string(REPLACE "/" "_" target "${fname}")
         string(REPLACE ".cc" "" target "${target}")
+        functions_framework_cpp_add_common_options(${target})
         add_test(NAME ${target} COMMAND ${target})
     endforeach ()
 endif ()

--- a/examples/site/testing_pubsub/CMakeLists.txt
+++ b/examples/site/testing_pubsub/CMakeLists.txt
@@ -27,6 +27,7 @@ if (BUILD_TESTING)
         string(REPLACE "/" "_" target "${fname}")
         string(REPLACE ".cc" "" target "${target}")
         add_executable("${target}" ${fname})
+        functions_framework_cpp_add_common_options(${target})
         target_link_libraries(
             ${target}
             PRIVATE functions_framework_examples

--- a/examples/site/testing_storage/CMakeLists.txt
+++ b/examples/site/testing_storage/CMakeLists.txt
@@ -27,6 +27,7 @@ if (BUILD_TESTING)
         string(REPLACE "/" "_" target "${fname}")
         string(REPLACE ".cc" "" target "${target}")
         add_executable("${target}" ${fname})
+        functions_framework_cpp_add_common_options(${target})
         target_link_libraries(
             ${target}
             PRIVATE functions_framework_examples
@@ -43,6 +44,7 @@ if (BUILD_TESTING)
         string(REPLACE "/" "_" target "${fname}")
         string(REPLACE ".cc" "" target "${target}")
         add_executable("${target}" ${fname})
+        functions_framework_cpp_add_common_options(${target})
         target_link_libraries(
             ${target}
             PRIVATE functions_framework_examples

--- a/google/cloud/functions/CMakeLists.txt
+++ b/google/cloud/functions/CMakeLists.txt
@@ -21,7 +21,7 @@ configure_file(internal/version_info.h.in
                ${CMAKE_CURRENT_SOURCE_DIR}/internal/version_info.h)
 
 find_package(absl REQUIRED)
-find_package(Boost REQUIRED COMPONENTS program_options filesystem)
+find_package(Boost REQUIRED COMPONENTS program_options)
 find_package(Threads REQUIRED)
 
 add_library(

--- a/google/cloud/functions/CMakeLists.txt
+++ b/google/cloud/functions/CMakeLists.txt
@@ -21,7 +21,7 @@ configure_file(internal/version_info.h.in
                ${CMAKE_CURRENT_SOURCE_DIR}/internal/version_info.h)
 
 find_package(absl REQUIRED)
-find_package(Boost REQUIRED COMPONENTS program_options)
+find_package(Boost REQUIRED COMPONENTS program_options filesystem)
 find_package(Threads REQUIRED)
 
 add_library(
@@ -55,9 +55,9 @@ add_library(
     user_functions.h
     version.cc
     version.h)
+functions_framework_cpp_add_common_options(functions_framework_cpp)
 target_include_directories(functions_framework_cpp
                            PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>)
-
 target_include_directories(functions_framework_cpp SYSTEM
                            PUBLIC $<INSTALL_INTERFACE:include>)
 target_link_libraries(
@@ -93,8 +93,10 @@ if (BUILD_TESTING)
         string(REPLACE ".cc" "" target "${target}")
         add_executable("${target}" ${fname})
         target_link_libraries(
-            ${target} PRIVATE functions-framework-cpp::framework
-                              GTest::gmock_main GTest::gmock GTest::gtest)
+            ${target}
+            PRIVATE functions-framework-cpp::framework GTest::gmock_main
+                    GTest::gmock GTest::gtest Boost::headers)
+        functions_framework_cpp_add_common_options(${target})
         add_test(NAME ${target} COMMAND ${target})
     endforeach ()
 

--- a/google/cloud/functions/integration_tests/CMakeLists.txt
+++ b/google/cloud/functions/integration_tests/CMakeLists.txt
@@ -28,6 +28,12 @@ foreach (fname ${functions_framework_cpp_integration_tests})
     target_link_libraries(
         ${target} PRIVATE functions-framework-cpp::framework GTest::gmock
                           GTest::gtest Boost::filesystem)
+    functions_framework_cpp_add_common_options(${target})
+    # I (coryan) am not sure why this is needed, but it only affects the tests,
+    # so I am more willing to tolerate it. I think normally Boost header-only
+    # libraries automatically declare when they need additional libraries with
+    # MSVC, but it does not seem to work here.
+    target_compile_definitions("${target}" PRIVATE BOOST_UUID_FORCE_AUTO_LINK)
     add_test(NAME ${target} COMMAND ${target})
 endforeach ()
 
@@ -41,4 +47,5 @@ foreach (fname ${functions_framework_cpp_integration_programs})
     string(REPLACE ".cc" "" target "${target}")
     add_executable("${target}" ${fname})
     target_link_libraries(${target} PRIVATE functions-framework-cpp::framework)
+    functions_framework_cpp_add_common_options(${target})
 endforeach ()


### PR DESCRIPTION
This is turned off by default because package maintainers and casual
users (which may have a different compiler than we do) should not see
breakage due to warnings.