### PR TITLE
fix: incorrect iterator access in base64 decoding

### DIFF
--- a/examples/site/hello_world_pubsub/hello_world_pubsub.cc
+++ b/examples/site/hello_world_pubsub/hello_world_pubsub.cc
@@ -46,14 +46,12 @@ std::string decode_base64(std::string const& base64) {
   // Pad the raw string if needed.
   auto padded = base64;
   padded.append((4 - padded.size() % 4) % 4, '=');
-  auto pad_begin = [&padded] {
-    auto const last_non_pad = padded.find_last_not_of('=');
-    if (last_non_pad == std::string::npos) return padded.end();
-    auto r = padded.begin();
-    std::advance(r, last_non_pad + 1);
-    return r;
-  }();
-  auto const pad_count = std::distance(pad_begin, padded.end());
+  // While we know how much padding we added, there may have been some padding
+  // there, just not enough. We need to determine the actual number of `=`
+  // characters at the end of th string.
+  auto const pad_count = std::distance(
+      padded.rbegin(), std::find_if(padded.rbegin(), padded.rend(),
+                                    [](auto c) { return c != '='; }));
 
   std::string data{Decoder(padded.begin()), Decoder(padded.end())};
   if (pad_count == 2) {

--- a/examples/site/hello_world_pubsub/hello_world_pubsub.cc
+++ b/examples/site/hello_world_pubsub/hello_world_pubsub.cc
@@ -49,9 +49,9 @@ std::string decode_base64(std::string const& base64) {
   // While we know how much padding we added, there may have been some padding
   // there, just not enough. We need to determine the actual number of `=`
   // characters at the end of th string.
-  auto pad_count = std::distance(
-      padded.rbegin(), std::find_if(padded.rbegin(), padded.rend(),
-                                    [](auto c) { return c != '='; }));
+  auto pad_count = std::distance(padded.rbegin(),
+                                 std::find_if(padded.rbegin(), padded.rend(),
+                                              [](auto c) { return c != '='; }));
   if (pad_count > 2) {
     throw std::invalid_argument("Invalid base64 string <" + base64 + ">");
   }

--- a/examples/site/hello_world_pubsub/hello_world_pubsub.cc
+++ b/examples/site/hello_world_pubsub/hello_world_pubsub.cc
@@ -48,7 +48,7 @@ std::string decode_base64(std::string const& base64) {
   padded.append((4 - padded.size() % 4) % 4, '=');
   // While we know how much padding we added, there may have been some padding
   // there, just not enough. We need to determine the actual number of `=`
-  // characters at the end of th string.
+  // characters at the end of the string.
   auto pad_count = std::distance(padded.rbegin(),
                                  std::find_if(padded.rbegin(), padded.rend(),
                                               [](auto c) { return c != '='; }));

--- a/examples/site/hello_world_pubsub/hello_world_pubsub.cc
+++ b/examples/site/hello_world_pubsub/hello_world_pubsub.cc
@@ -52,6 +52,9 @@ std::string decode_base64(std::string const& base64) {
   auto pad_count = std::distance(
       padded.rbegin(), std::find_if(padded.rbegin(), padded.rend(),
                                     [](auto c) { return c != '='; }));
+  if (pad_count > 2) {
+    throw std::invalid_argument("Invalid base64 string <" + base64 + ">");
+  }
 
   std::string data{Decoder(padded.begin()), Decoder(padded.end())};
   for (; pad_count != 0; --pad_count) data.pop_back();

--- a/examples/site/hello_world_pubsub/hello_world_pubsub.cc
+++ b/examples/site/hello_world_pubsub/hello_world_pubsub.cc
@@ -49,16 +49,11 @@ std::string decode_base64(std::string const& base64) {
   // While we know how much padding we added, there may have been some padding
   // there, just not enough. We need to determine the actual number of `=`
   // characters at the end of th string.
-  auto const pad_count = std::distance(
+  auto pad_count = std::distance(
       padded.rbegin(), std::find_if(padded.rbegin(), padded.rend(),
                                     [](auto c) { return c != '='; }));
 
   std::string data{Decoder(padded.begin()), Decoder(padded.end())};
-  if (pad_count == 2) {
-    data.pop_back();
-    data.pop_back();
-  } else if (pad_count == 1) {
-    data.pop_back();
-  }
+  for (; pad_count != 0; --pad_count) data.pop_back();
   return data;
 }

--- a/examples/site/hello_world_pubsub/hello_world_pubsub.cc
+++ b/examples/site/hello_world_pubsub/hello_world_pubsub.cc
@@ -45,10 +45,16 @@ std::string decode_base64(std::string const& base64) {
                            kBase64EncodedBits, kBase64RawBits>;
   // Pad the raw string if needed.
   auto padded = base64;
-  padded.append((4 - base64.size() % 4) % 4, '=');
-  auto const last_non_pad = base64.find_last_not_of('=');
-  auto const pad_count =
-      std::distance(padded.begin() + last_non_pad + 1, padded.end());
+  padded.append((4 - padded.size() % 4) % 4, '=');
+  auto pad_begin = [&padded] {
+    auto const last_non_pad = padded.find_last_not_of('=');
+    if (last_non_pad == std::string::npos) return padded.end();
+    auto r = padded.begin();
+    std::advance(r, last_non_pad + 1);
+    return r;
+  }();
+  auto const pad_count = std::distance(pad_begin, padded.end());
+
   std::string data{Decoder(padded.begin()), Decoder(padded.end())};
   if (pad_count == 2) {
     data.pop_back();

--- a/google/cloud/functions/internal/parse_cloud_event_json.cc
+++ b/google/cloud/functions/internal/parse_cloud_event_json.cc
@@ -56,9 +56,15 @@ functions::CloudEvent ParseCloudEventJson(nlohmann::json const& json) {
                              kBase64EncodedBits, kBase64RawBits>;
     // Pad the raw string if needed.
     base64.append((4 - base64.size() % 4) % 4, '=');
-    auto const last_non_pad = base64.find_last_not_of('=');
-    auto const pad_count =
-        std::distance(base64.begin() + last_non_pad + 1, base64.end());
+    auto pad_begin = [&base64] {
+      auto const last_non_pad = base64.find_last_not_of('=');
+      if (last_non_pad == std::string::npos) return base64.end();
+      auto r = base64.begin();
+      std::advance(r, last_non_pad + 1);
+      return r;
+    }();
+    auto const pad_count = std::distance(pad_begin, base64.end());
+
     std::string data{Decoder(base64.begin()), Decoder(base64.end())};
     if (pad_count == 2) {
       data.pop_back();

--- a/google/cloud/functions/internal/parse_cloud_event_json.cc
+++ b/google/cloud/functions/internal/parse_cloud_event_json.cc
@@ -56,14 +56,12 @@ functions::CloudEvent ParseCloudEventJson(nlohmann::json const& json) {
                              kBase64EncodedBits, kBase64RawBits>;
     // Pad the raw string if needed.
     base64.append((4 - base64.size() % 4) % 4, '=');
-    auto pad_begin = [&base64] {
-      auto const last_non_pad = base64.find_last_not_of('=');
-      if (last_non_pad == std::string::npos) return base64.end();
-      auto r = base64.begin();
-      std::advance(r, last_non_pad + 1);
-      return r;
-    }();
-    auto const pad_count = std::distance(pad_begin, base64.end());
+    // While we know how much padding we added, there may have been some padding
+    // there, just not enough. We need to determine the actual number of `=`
+    // characters at the end of th string.
+    auto const pad_count = std::distance(
+        base64.rbegin(), std::find_if(base64.rbegin(), base64.rend(),
+                                      [](auto c) { return c != '='; }));
 
     std::string data{Decoder(base64.begin()), Decoder(base64.end())};
     if (pad_count == 2) {

--- a/google/cloud/functions/internal/parse_cloud_event_json.cc
+++ b/google/cloud/functions/internal/parse_cloud_event_json.cc
@@ -58,7 +58,7 @@ functions::CloudEvent ParseCloudEventJson(nlohmann::json const& json) {
     base64.append((4 - base64.size() % 4) % 4, '=');
     // While we know how much padding we added, there may have been some padding
     // there, just not enough. We need to determine the actual number of `=`
-    // characters at the end of th string.
+    // characters at the end of the string.
     auto pad_count = std::distance(
         base64.rbegin(), std::find_if(base64.rbegin(), base64.rend(),
                                       [](auto c) { return c != '='; }));

--- a/google/cloud/functions/internal/parse_cloud_event_json.cc
+++ b/google/cloud/functions/internal/parse_cloud_event_json.cc
@@ -62,6 +62,9 @@ functions::CloudEvent ParseCloudEventJson(nlohmann::json const& json) {
     auto pad_count = std::distance(
         base64.rbegin(), std::find_if(base64.rbegin(), base64.rend(),
                                       [](auto c) { return c != '='; }));
+    if (pad_count > 2) {
+      throw std::invalid_argument("Invalid base64 string <" + base64 + ">");
+    }
 
     std::string data{Decoder(base64.begin()), Decoder(base64.end())};
     for (; pad_count != 0; --pad_count) data.pop_back();

--- a/google/cloud/functions/internal/parse_cloud_event_json.cc
+++ b/google/cloud/functions/internal/parse_cloud_event_json.cc
@@ -59,17 +59,12 @@ functions::CloudEvent ParseCloudEventJson(nlohmann::json const& json) {
     // While we know how much padding we added, there may have been some padding
     // there, just not enough. We need to determine the actual number of `=`
     // characters at the end of th string.
-    auto const pad_count = std::distance(
+    auto pad_count = std::distance(
         base64.rbegin(), std::find_if(base64.rbegin(), base64.rend(),
                                       [](auto c) { return c != '='; }));
 
     std::string data{Decoder(base64.begin()), Decoder(base64.end())};
-    if (pad_count == 2) {
-      data.pop_back();
-      data.pop_back();
-    } else if (pad_count == 1) {
-      data.pop_back();
-    }
+    for (; pad_count != 0; --pad_count) data.pop_back();
     // TODO(#117) - consider storing as std::vector<std::uint8_t>
     event.set_data(std::move(data));
   }

--- a/google/cloud/functions/internal/parse_cloud_event_json_test.cc
+++ b/google/cloud/functions/internal/parse_cloud_event_json_test.cc
@@ -207,6 +207,11 @@ TEST(ParseCloudEventJson, WithDataBase64Padding) {
     "source" : "/mycontext",
     "id" : "A234-1234-1234",
     "data_base64" : "YQ=="})js"},
+      {"a", R"js({
+    "type" : "com.example.someevent",
+    "source" : "/mycontext",
+    "id" : "A234-1234-1234",
+    "data_base64" : "YQ="})js"},
       {"ab", R"js({
     "type" : "com.example.someevent",
     "source" : "/mycontext",
@@ -222,6 +227,13 @@ TEST(ParseCloudEventJson, WithDataBase64Padding) {
     auto const ce = ParseCloudEventJson(c.json);
     EXPECT_EQ(ce.data().value_or(""), c.expected_data);
   }
+
+  auto constexpr kExcessivePadding = R"js({
+    "type" : "com.example.someevent",
+    "source" : "/mycontext",
+    "id" : "A234-1234-1234",
+    "data_base64" : "YWJj============"})js";
+  EXPECT_THROW(ParseCloudEventJson(kExcessivePadding), std::invalid_argument);
 }
 
 TEST(ParseCloudEventJson, Batch) {


### PR DESCRIPTION
I would not have noticed this, but MSVC (with the right warnings) did.
More fixes to get the code to compile on MSVC will be coming in future
PRs, but this is useful by itself.