### PR TITLE
cleanup: no vcpkg needed in install builds

### DIFF
--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -5,9 +5,6 @@ on:
     branches: [ main ]
   pull_request:
 
-env:
-  vcpkg_SHA: "5214a247018b3bf2d793cea188ea2f2c150daddd"
-
 jobs:
   static:
     name: ubuntu-20.04
@@ -25,26 +22,6 @@ jobs:
           sudo cmake --build cmake-out/abseil --target install &&
           sudo ldconfig
       - uses: actions/checkout@v2
-      - name: clone-vcpkg
-        working-directory: "${{runner.temp}}"
-        run: >
-          mkdir -p vcpkg &&
-          curl -sSL "https://github.com/microsoft/vcpkg/archive/${{env.vcpkg_SHA}}.tar.gz" |
-          tar -C vcpkg --strip-components=1 -zxf -
-      - name: cache-vcpkg
-        id: cache-vcpkg
-        uses: actions/cache@v2
-        with:
-          # Preserve the vcpkg binary *and* the vcpkg binary cache in the build cache
-          path: |
-            ~/.cache/vcpkg
-            ~/.cache/bin
-          key: |
-            vcpkg-${{ env.vcpkg_SHA }}-install-static-${{ hashFiles('vcpkg.json') }}
-          restore-keys: |
-            vcpkg-${{ env.vcpkg_SHA }}-install-static-
-      - name: boostrap-vcpkg
-        run: ci/restore-vcpkg-from-cache.sh "${{runner.temp}}/vcpkg"
       - name: configure
         run: >
           cmake -S . -B ${{runner.temp}}/build -GNinja -DBUILD_TESTING=OFF


### PR DESCRIPTION
The point of these builds is to check `make install`, I am not sure why
I had vcpkg installed, as it was not used.