### PR TITLE
test: fix integration test to run in parallel

### DIFF
--- a/examples/site/testing_http/http_integration_test.cc
+++ b/examples/site/testing_http/http_integration_test.cc
@@ -48,8 +48,8 @@ class HttpIntegrationTest : public ::testing::Test {
     }
     curl_global_init(CURL_GLOBAL_ALL);
     auto const exe = bfs::path(argv0).parent_path() / "http_integration_server";
-    auto server = bp::child(exe, "--port=8080");
-    url_ = "http://localhost:8080";
+    auto server = bp::child(exe, "--port=8030");
+    url_ = "http://localhost:8030";
     ASSERT_TRUE(WaitForServerReady(url_));
     process_ = std::move(server);
   }

--- a/examples/site/testing_pubsub/pubsub_integration_test.cc
+++ b/examples/site/testing_pubsub/pubsub_integration_test.cc
@@ -45,8 +45,8 @@ class PubsubIntegrationTest : public ::testing::Test {
     auto const exe =
         bfs::path(argv0).parent_path() / "pubsub_integration_server";
     auto server =
-        bp::child(exe, "--port=8081", (bp::std_out & bp::std_err) > child_log_);
-    ASSERT_TRUE(WaitForServerReady("http://localhost:8081/"));
+        bp::child(exe, "--port=8040", (bp::std_out & bp::std_err) > child_log_);
+    ASSERT_TRUE(WaitForServerReady("http://localhost:8040/"));
     process_ = std::move(server);
   }
 
@@ -102,7 +102,7 @@ TEST_F(PubsubIntegrationTest, Basic) {
     auto object = base;
     object["data"]["message"] = nlohmann::json{{"data", test.data}};
     SCOPED_TRACE("event=" + object.dump());
-    auto actual = HttpEvent("http://localhost:8081/", object.dump());
+    auto actual = HttpEvent("http://localhost:8040/", object.dump());
     EXPECT_EQ(actual.code, kOkay);
     EXPECT_THAT(actual.payload, IsEmpty());
 

--- a/examples/site/testing_storage/storage_integration_test.cc
+++ b/examples/site/testing_storage/storage_integration_test.cc
@@ -46,8 +46,8 @@ class StorageIntegrationTest : public ::testing::Test {
     auto const exe =
         bfs::path(argv0).parent_path() / "storage_integration_server";
     auto server =
-        bp::child(exe, "--port=8082", (bp::std_out & bp::std_err) > child_log_);
-    ASSERT_TRUE(WaitForServerReady("http://localhost:8082/"));
+        bp::child(exe, "--port=8050", (bp::std_out & bp::std_err) > child_log_);
+    ASSERT_TRUE(WaitForServerReady("http://localhost:8050/"));
     process_ = std::move(server);
   }
 
@@ -106,7 +106,7 @@ TEST_F(StorageIntegrationTest, Basic) {
     auto object = base;
     object["data"]["name"] = test.name;
     SCOPED_TRACE("event=" + object.dump());
-    auto actual = HttpEvent("http://localhost:8082/", object.dump());
+    auto actual = HttpEvent("http://localhost:8050/", object.dump());
     ASSERT_EQ(actual.code, kOkay);
     EXPECT_THAT(actual.payload, IsEmpty());
 

--- a/google/cloud/functions/integration_tests/basic_integration_test.cc
+++ b/google/cloud/functions/integration_tests/basic_integration_test.cc
@@ -85,35 +85,35 @@ auto constexpr kConformanceServer = "http_conformance";
 
 TEST(RunIntegrationTest, Basic) {
   auto const exe = bfs::path(argv0).parent_path() / kServer;
-  auto server = bp::child(exe, "--port=8080");
-  auto result = WaitForServerReady("localhost", "8080");
+  auto server = bp::child(exe, "--port=8010");
+  auto result = WaitForServerReady("localhost", "8010");
   ASSERT_EQ(result, 0);
 
-  auto actual = HttpGet("localhost", "8080", "/say/hello");
+  auto actual = HttpGet("localhost", "8010", "/say/hello");
   EXPECT_EQ(actual.result_int(), functions::HttpResponse::kOkay);
   EXPECT_THAT(actual.body(), HasSubstr(R"js("target": "/say/hello")js"));
 
   actual =
-      HttpGet("localhost", "8080",
+      HttpGet("localhost", "8010",
               "/error/" + std::to_string(functions::HttpResponse::kNotFound));
   EXPECT_THAT(actual.result_int(), functions::HttpResponse::kNotFound);
 
-  actual = HttpGet("localhost", "8080", "/exception/");
+  actual = HttpGet("localhost", "8010", "/exception/");
   EXPECT_THAT(actual.result_int(),
               functions::HttpResponse::kInternalServerError);
 
-  actual = HttpGet("localhost", "8080", "/unknown-exception/");
+  actual = HttpGet("localhost", "8010", "/unknown-exception/");
   EXPECT_THAT(actual.result_int(),
               functions::HttpResponse::kInternalServerError);
 
-  actual = HttpGet("localhost", "8080", "/favicon.ico");
+  actual = HttpGet("localhost", "8010", "/favicon.ico");
   EXPECT_THAT(actual.result_int(), functions::HttpResponse::kNotFound);
 
-  actual = HttpGet("localhost", "8080", "/robots.txt");
+  actual = HttpGet("localhost", "8010", "/robots.txt");
   EXPECT_THAT(actual.result_int(), functions::HttpResponse::kNotFound);
 
   try {
-    (void)HttpGet("localhost", "8080", "/quit/program/0");
+    (void)HttpGet("localhost", "8010", "/quit/program/0");
   } catch (...) {
   }
   server.wait();
@@ -123,11 +123,11 @@ TEST(RunIntegrationTest, Basic) {
 TEST(RunIntegrationTest, ExceptionLogsToStderr) {
   auto const exe = bfs::path(argv0).parent_path() / kServer;
   bp::ipstream child_stderr;
-  auto server = bp::child(exe, "--port=8080", bp::std_err > child_stderr);
-  auto result = WaitForServerReady("localhost", "8080");
+  auto server = bp::child(exe, "--port=8010", bp::std_err > child_stderr);
+  auto result = WaitForServerReady("localhost", "8010");
   ASSERT_EQ(result, 0);
 
-  auto actual = HttpGet("localhost", "8080", "/exception/test-string");
+  auto actual = HttpGet("localhost", "8010", "/exception/test-string");
   EXPECT_THAT(actual.result_int(),
               functions::HttpResponse::kInternalServerError);
 
@@ -137,7 +137,7 @@ TEST(RunIntegrationTest, ExceptionLogsToStderr) {
   EXPECT_THAT(line, HasSubstr("/exception/test-string"));
 
   try {
-    (void)HttpGet("localhost", "8080", "/quit/program/0");
+    (void)HttpGet("localhost", "8010", "/quit/program/0");
   } catch (...) {
   }
   server.wait();
@@ -148,27 +148,28 @@ TEST(RunIntegrationTest, OutputIsFlushed) {
   auto const exe = bfs::path(argv0).parent_path() / kServer;
   bp::ipstream child_stderr;
   bp::ipstream child_stdout;
-  auto server = bp::child(exe, "--port=8080", bp::std_err > child_stderr,
-                          bp::std_out > child_stdout);
-  auto result = WaitForServerReady("localhost", "8080");
+  auto server =
+      bp::child(exe, "--port=8010", bp::std_err > child_stderr,
+                bp::std_out > child_stdout);
+  auto result = WaitForServerReady("localhost", "8010");
   ASSERT_EQ(result, 0);
 
   std::string line;
 
-  auto actual = HttpGet("localhost", "8080", "/buffered-stdout/test-string");
+  auto actual = HttpGet("localhost", "8010", "/buffered-stdout/test-string");
   EXPECT_THAT(actual.result_int(), functions::HttpResponse::kOkay);
   EXPECT_TRUE(std::getline(child_stdout, line));
   EXPECT_THAT(line, HasSubstr("stdout:"));
   EXPECT_THAT(line, HasSubstr("/buffered-stdout/test-string"));
 
-  actual = HttpGet("localhost", "8080", "/buffered-stderr/test-string");
+  actual = HttpGet("localhost", "8010", "/buffered-stderr/test-string");
   EXPECT_THAT(actual.result_int(), functions::HttpResponse::kOkay);
   EXPECT_TRUE(std::getline(child_stderr, line));
   EXPECT_THAT(line, HasSubstr("stderr:"));
   EXPECT_THAT(line, HasSubstr("/buffered-stderr/test-string"));
 
   try {
-    (void)HttpGet("localhost", "8080", "/quit/program/0");
+    (void)HttpGet("localhost", "8010", "/quit/program/0");
   } catch (...) {
   }
   server.wait();
@@ -177,12 +178,12 @@ TEST(RunIntegrationTest, OutputIsFlushed) {
 
 TEST(RunIntegrationTest, ConformanceSmokeTest) {
   auto const exe = bfs::path(argv0).parent_path() / kConformanceServer;
-  auto server = bp::child(exe, "--port=8080");
-  auto result = WaitForServerReady("localhost", "8080");
+  auto server = bp::child(exe, "--port=8010");
+  auto result = WaitForServerReady("localhost", "8010");
   ASSERT_EQ(result, 0);
 
   try {
-    (void)HttpGet("localhost", "8080", "/quit/program/0");
+    (void)HttpGet("localhost", "8010", "/quit/program/0");
   } catch (...) {
   }
   server.wait();

--- a/google/cloud/functions/integration_tests/basic_integration_test.cc
+++ b/google/cloud/functions/integration_tests/basic_integration_test.cc
@@ -148,9 +148,8 @@ TEST(RunIntegrationTest, OutputIsFlushed) {
   auto const exe = bfs::path(argv0).parent_path() / kServer;
   bp::ipstream child_stderr;
   bp::ipstream child_stdout;
-  auto server =
-      bp::child(exe, "--port=8010", bp::std_err > child_stderr,
-                bp::std_out > child_stdout);
+  auto server = bp::child(exe, "--port=8010", bp::std_err > child_stderr,
+                          bp::std_out > child_stdout);
   auto result = WaitForServerReady("localhost", "8010");
   ASSERT_EQ(result, 0);
 

--- a/google/cloud/functions/internal/parse_cloud_event_json.cc
+++ b/google/cloud/functions/internal/parse_cloud_event_json.cc
@@ -56,9 +56,15 @@ functions::CloudEvent ParseCloudEventJson(nlohmann::json const& json) {
                              kBase64EncodedBits, kBase64RawBits>;
     // Pad the raw string if needed.
     base64.append((4 - base64.size() % 4) % 4, '=');
-    auto const last_non_pad = base64.find_last_not_of('=');
-    auto const pad_count =
-        std::distance(base64.begin() + last_non_pad + 1, base64.end());
+    auto pad_begin = [&base64] {
+      auto const last_non_pad = base64.find_last_not_of('=');
+      if (last_non_pad == std::string::npos) return base64.end();
+      auto r = base64.begin();
+      std::advance(r, last_non_pad + 1);
+      return r;
+    }();
+    auto const pad_count = std::distance(pad_begin, base64.end());
+
     std::string data{Decoder(base64.begin()), Decoder(base64.end())};
     if (pad_count == 2) {
       data.pop_back();

--- a/google/cloud/functions/internal/parse_cloud_event_json.cc
+++ b/google/cloud/functions/internal/parse_cloud_event_json.cc
@@ -56,15 +56,9 @@ functions::CloudEvent ParseCloudEventJson(nlohmann::json const& json) {
                              kBase64EncodedBits, kBase64RawBits>;
     // Pad the raw string if needed.
     base64.append((4 - base64.size() % 4) % 4, '=');
-    auto pad_begin = [&base64] {
-      auto const last_non_pad = base64.find_last_not_of('=');
-      if (last_non_pad == std::string::npos) return base64.end();
-      auto r = base64.begin();
-      std::advance(r, last_non_pad + 1);
-      return r;
-    }();
-    auto const pad_count = std::distance(pad_begin, base64.end());
-
+    auto const last_non_pad = base64.find_last_not_of('=');
+    auto const pad_count =
+        std::distance(base64.begin() + last_non_pad + 1, base64.end());
     std::string data{Decoder(base64.begin()), Decoder(base64.end())};
     if (pad_count == 2) {
       data.pop_back();


### PR DESCRIPTION
Many of the integration tests were using the same port, which stopped us
from running them in parallel. Found while testing on Windows, but
affects Linux too.