### PR TITLE
feat: fix compilation problems on MSVC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,5 @@ cmake-build-*/
 # Ignore Visual Studio Code files
 .vsbuild/
 .vscode/
+build/
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -51,6 +51,12 @@ add_library(
     site/tips_retry/tips_retry.cc
     site/tips_scopes/tips_scopes.cc)
 functions_framework_cpp_add_common_options(functions_framework_examples)
+if (MSVC)
+    set_property(
+        SOURCE site/tips_gcp_apis/tips_gcp_apis.cc site/env_vars/env_vars.cc
+        APPEND
+        PROPERTY COMPILE_DEFINITIONS _CRT_SECURE_NO_WARNINGS)
+endif ()
 target_link_libraries(
     functions_framework_examples fmt::fmt functions-framework-cpp::framework
     google-cloud-cpp::pubsub google-cloud-cpp::storage)

--- a/examples/site/testing_http/CMakeLists.txt
+++ b/examples/site/testing_http/CMakeLists.txt
@@ -32,6 +32,10 @@ if (BUILD_TESTING)
         string(REPLACE ".cc" "" target "${target}")
         add_executable("${target}" ${fname})
         functions_framework_cpp_add_common_options(${target})
+        if (MSVC)
+            target_compile_definitions(${target}
+                                       PRIVATE "_CRT_SECURE_NO_WARNINGS")
+        endif ()
         target_link_libraries(
             ${target}
             PRIVATE functions_framework_examples

--- a/examples/site/testing_http/http_integration_test.cc
+++ b/examples/site/testing_http/http_integration_test.cc
@@ -38,6 +38,12 @@ HttpResponse HttpGet(std::string const& url, std::string const& payload);
 
 char const* argv0 = nullptr;
 
+auto ExePath(bfs::path const& filename) {
+  static auto const kPath = std::vector<bfs::path>{
+      bfs::canonical(argv0).make_preferred().parent_path()};
+  return bp::search_path(filename, kPath);
+}
+
 class HttpIntegrationTest : public ::testing::Test {
  protected:
   void SetUp() override {
@@ -47,8 +53,7 @@ class HttpIntegrationTest : public ::testing::Test {
       return;
     }
     curl_global_init(CURL_GLOBAL_ALL);
-    auto const exe = bfs::path(argv0).parent_path() / "http_integration_server";
-    auto server = bp::child(exe, "--port=8030");
+    auto server = bp::child(ExePath("http_integration_server"), "--port=8030");
     url_ = "http://localhost:8030";
     ASSERT_TRUE(WaitForServerReady(url_));
     process_ = std::move(server);

--- a/examples/site/testing_pubsub/pubsub_integration_test.cc
+++ b/examples/site/testing_pubsub/pubsub_integration_test.cc
@@ -42,8 +42,9 @@ class PubsubIntegrationTest : public ::testing::Test {
   void SetUp() override {
     curl_global_init(CURL_GLOBAL_ALL);
 
-    auto const exe =
-        bfs::path(argv0).parent_path() / "pubsub_integration_server";
+    static auto const kPath = std::vector<bfs::path>{
+        bfs::canonical(argv0).make_preferred().parent_path()};
+    auto const exe = bp::search_path("pubsub_integration_server", kPath);
     auto server =
         bp::child(exe, "--port=8040", (bp::std_out & bp::std_err) > child_log_);
     ASSERT_TRUE(WaitForServerReady("http://localhost:8040/"));

--- a/examples/site/testing_storage/storage_integration_test.cc
+++ b/examples/site/testing_storage/storage_integration_test.cc
@@ -43,8 +43,9 @@ class StorageIntegrationTest : public ::testing::Test {
   void SetUp() override {
     curl_global_init(CURL_GLOBAL_ALL);
 
-    auto const exe =
-        bfs::path(argv0).parent_path() / "storage_integration_server";
+    static auto const kPath = std::vector<bfs::path>{
+        bfs::canonical(argv0).make_preferred().parent_path()};
+    auto const exe = bp::search_path("storage_integration_server", kPath);
     auto server =
         bp::child(exe, "--port=8050", (bp::std_out & bp::std_err) > child_log_);
     ASSERT_TRUE(WaitForServerReady("http://localhost:8050/"));

--- a/examples/site/testing_storage/storage_integration_test.cc
+++ b/examples/site/testing_storage/storage_integration_test.cc
@@ -38,16 +38,20 @@ HttpResponse HttpEvent(std::string const& url, std::string const& payload);
 
 char const* argv0 = nullptr;
 
+auto ExePath(bfs::path const& filename) {
+  static auto const kPath = std::vector<bfs::path>{
+      bfs::canonical(argv0).make_preferred().parent_path()};
+  return bp::search_path(filename, kPath);
+}
+
 class StorageIntegrationTest : public ::testing::Test {
  protected:
   void SetUp() override {
     curl_global_init(CURL_GLOBAL_ALL);
 
-    static auto const kPath = std::vector<bfs::path>{
-        bfs::canonical(argv0).make_preferred().parent_path()};
-    auto const exe = bp::search_path("storage_integration_server", kPath);
     auto server =
-        bp::child(exe, "--port=8050", (bp::std_out & bp::std_err) > child_log_);
+        bp::child(ExePath("storage_integration_server"), "--port=8050",
+                  (bp::std_out & bp::std_err) > child_log_);
     ASSERT_TRUE(WaitForServerReady("http://localhost:8050/"));
     process_ = std::move(server);
   }

--- a/google/cloud/functions/CMakeLists.txt
+++ b/google/cloud/functions/CMakeLists.txt
@@ -47,6 +47,8 @@ add_library(
     internal/parse_cloud_event_json.h
     internal/parse_options.cc
     internal/parse_options.h
+    internal/setenv.cc
+    internal/setenv.h
     internal/version_info.h
     internal/wrap_request.cc
     internal/wrap_request.h
@@ -56,6 +58,12 @@ add_library(
     version.cc
     version.h)
 functions_framework_cpp_add_common_options(functions_framework_cpp)
+if (MSVC)
+    set_property(
+        SOURCE internal/parse_options.cc
+        APPEND
+        PROPERTY COMPILE_DEFINITIONS "_CRT_SECURE_NO_WARNINGS")
+endif ()
 target_include_directories(functions_framework_cpp
                            PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>)
 target_include_directories(functions_framework_cpp SYSTEM

--- a/google/cloud/functions/integration_tests/basic_integration_test.cc
+++ b/google/cloud/functions/integration_tests/basic_integration_test.cc
@@ -83,9 +83,14 @@ char const* argv0 = nullptr;
 auto constexpr kServer = "echo_server";
 auto constexpr kConformanceServer = "http_conformance";
 
+auto ExePath(bfs::path const& filename) {
+  static auto const kPath = std::vector<bfs::path>{
+      bfs::canonical(argv0).make_preferred().parent_path()};
+  return bp::search_path(filename, kPath);
+}
+
 TEST(RunIntegrationTest, Basic) {
-  auto const exe = bfs::path(argv0).parent_path() / kServer;
-  auto server = bp::child(exe, "--port=8010");
+  auto server = bp::child(ExePath(kServer), "--port=8010");
   auto result = WaitForServerReady("localhost", "8010");
   ASSERT_EQ(result, 0);
 
@@ -121,9 +126,9 @@ TEST(RunIntegrationTest, Basic) {
 }
 
 TEST(RunIntegrationTest, ExceptionLogsToStderr) {
-  auto const exe = bfs::path(argv0).parent_path() / kServer;
   bp::ipstream child_stderr;
-  auto server = bp::child(exe, "--port=8010", bp::std_err > child_stderr);
+  auto server =
+      bp::child(ExePath(kServer), "--port=8010", bp::std_err > child_stderr);
   auto result = WaitForServerReady("localhost", "8010");
   ASSERT_EQ(result, 0);
 
@@ -145,11 +150,11 @@ TEST(RunIntegrationTest, ExceptionLogsToStderr) {
 }
 
 TEST(RunIntegrationTest, OutputIsFlushed) {
-  auto const exe = bfs::path(argv0).parent_path() / kServer;
   bp::ipstream child_stderr;
   bp::ipstream child_stdout;
-  auto server = bp::child(exe, "--port=8010", bp::std_err > child_stderr,
-                          bp::std_out > child_stdout);
+  auto server =
+      bp::child(ExePath(kServer), "--port=8010", bp::std_err > child_stderr,
+                bp::std_out > child_stdout);
   auto result = WaitForServerReady("localhost", "8010");
   ASSERT_EQ(result, 0);
 
@@ -176,8 +181,7 @@ TEST(RunIntegrationTest, OutputIsFlushed) {
 }
 
 TEST(RunIntegrationTest, ConformanceSmokeTest) {
-  auto const exe = bfs::path(argv0).parent_path() / kConformanceServer;
-  auto server = bp::child(exe, "--port=8010");
+  auto server = bp::child(ExePath(kConformanceServer), "--port=8010");
   auto result = WaitForServerReady("localhost", "8010");
   ASSERT_EQ(result, 0);
 

--- a/google/cloud/functions/integration_tests/cloud_event_integration_test.cc
+++ b/google/cloud/functions/integration_tests/cloud_event_integration_test.cc
@@ -170,9 +170,14 @@ char const* argv0 = nullptr;
 auto constexpr kServer = "cloud_event_handler";
 auto constexpr kConformanceServer = "cloud_event_conformance";
 
+auto ExePath(bfs::path const& filename) {
+  static auto const kPath = std::vector<bfs::path>{
+      bfs::canonical(argv0).make_preferred().parent_path()};
+  return bp::search_path(filename, kPath);
+}
+
 TEST(RunIntegrationTest, Basic) {
-  auto const exe = bfs::path(argv0).parent_path() / kServer;
-  auto server = bp::child(exe, "--port=8020");
+  auto server = bp::child(ExePath(kServer), "--port=8020");
   auto result = WaitForServerReady("localhost", "8020");
   ASSERT_EQ(result, 0);
 
@@ -202,8 +207,7 @@ TEST(RunIntegrationTest, Basic) {
 }
 
 TEST(RunIntegrationTest, Batch) {
-  auto const exe = bfs::path(argv0).parent_path() / kServer;
-  auto server = bp::child(exe, "--port=8020");
+  auto server = bp::child(ExePath(kServer), "--port=8020");
   auto result = WaitForServerReady("localhost", "8020");
   ASSERT_EQ(result, 0);
 
@@ -218,8 +222,7 @@ TEST(RunIntegrationTest, Batch) {
 }
 
 TEST(RunIntegrationTest, Binary) {
-  auto const exe = bfs::path(argv0).parent_path() / kServer;
-  auto server = bp::child(exe, "--port=8020");
+  auto server = bp::child(ExePath(kServer), "--port=8020");
   auto result = WaitForServerReady("localhost", "8020");
   ASSERT_EQ(result, 0);
 
@@ -234,9 +237,9 @@ TEST(RunIntegrationTest, Binary) {
 }
 
 TEST(RunIntegrationTest, ExceptionLogsToStderr) {
-  auto const exe = bfs::path(argv0).parent_path() / kServer;
   bp::ipstream child_stderr;
-  auto server = bp::child(exe, "--port=8020", bp::std_err > child_stderr);
+  auto server =
+      bp::child(ExePath(kServer), "--port=8020", bp::std_err > child_stderr);
   auto result = WaitForServerReady("localhost", "8020");
   ASSERT_EQ(result, 0);
 
@@ -258,11 +261,11 @@ TEST(RunIntegrationTest, ExceptionLogsToStderr) {
 }
 
 TEST(RunIntegrationTest, OutputIsFlushed) {
-  auto const exe = bfs::path(argv0).parent_path() / kServer;
   bp::ipstream child_stderr;
   bp::ipstream child_stdout;
-  auto server = bp::child(exe, "--port=8020", bp::std_err > child_stderr,
-                          bp::std_out > child_stdout);
+  auto server =
+      bp::child(ExePath(kServer), "--port=8020", bp::std_err > child_stderr,
+                bp::std_out > child_stdout);
   auto result = WaitForServerReady("localhost", "8020");
   ASSERT_EQ(result, 0);
 
@@ -289,8 +292,7 @@ TEST(RunIntegrationTest, OutputIsFlushed) {
 }
 
 TEST(RunIntegrationTest, ConformanceSmokeTest) {
-  auto const exe = bfs::path(argv0).parent_path() / kConformanceServer;
-  auto server = bp::child(exe, "--port=8020");
+  auto server = bp::child(ExePath(kConformanceServer), "--port=8020");
   auto result = WaitForServerReady("localhost", "8020");
   ASSERT_EQ(result, 0);
 

--- a/google/cloud/functions/internal/compiler_info_test.cc
+++ b/google/cloud/functions/internal/compiler_info_test.cc
@@ -33,10 +33,11 @@ TEST(CompilerInfo, CompilerId) {
 TEST(CompilerInfo, CompilerVersion) {
   auto const cv = CompilerVersion();
   EXPECT_NE(cv, "");
-  // Look for something that looks vaguely like an X.Y version number.
-  // Cannot use a regex because GTest does not have them with MSVC.
+  // Look for something that looks vaguely like an X.Y version number. Cannot
+  // use ::testing::ContainsRegex() because these do not work when GTest is
+  // compiled under MSVC.
   EXPECT_THAT(cv, Contains('.'));
-  EXPECT_TRUE(std::regex_match(cv, std::regex(R"(^[0-9]+\.[0-9]+.*)")))
+  EXPECT_TRUE(std::regex_search(cv, std::regex(R"([0-9]+\.[0-9]+)")))
       << "version=" << cv;
 }
 

--- a/google/cloud/functions/internal/compiler_info_test.cc
+++ b/google/cloud/functions/internal/compiler_info_test.cc
@@ -34,7 +34,7 @@ TEST(CompilerInfo, CompilerVersion) {
   auto const cv = CompilerVersion();
   EXPECT_NE(cv, "");
   // Look for something that looks vaguely like an X.Y version number. Cannot
-  // use ::testing::ContainsRegex() because these do not work when GTest is
+  // use ::testing::ContainsRegex() because that does not work when GTest is
   // compiled under MSVC.
   EXPECT_THAT(cv, Contains('.'));
   EXPECT_TRUE(std::regex_search(cv, std::regex(R"([0-9]+\.[0-9]+)")))

--- a/google/cloud/functions/internal/compiler_info_test.cc
+++ b/google/cloud/functions/internal/compiler_info_test.cc
@@ -14,10 +14,13 @@
 
 #include "google/cloud/functions/internal/compiler_info.h"
 #include <gmock/gmock.h>
+#include <regex>
 
 namespace google::cloud::functions_internal {
 inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
 namespace {
+
+using ::testing::Contains;
 
 TEST(CompilerInfo, CompilerId) {
   auto const cn = CompilerId();
@@ -31,7 +34,10 @@ TEST(CompilerInfo, CompilerVersion) {
   auto const cv = CompilerVersion();
   EXPECT_NE(cv, "");
   // Look for something that looks vaguely like an X.Y version number.
-  EXPECT_THAT(cv, ::testing::ContainsRegex(R"([0-9]+.[0-9]+)"));
+  // Cannot use a regex because GTest does not have them with MSVC.
+  EXPECT_THAT(cv, Contains('.'));
+  EXPECT_TRUE(std::regex_match(cv, std::regex(R"(^[0-9]+\.[0-9]+.*)")))
+      << "version=" << cv;
 }
 
 TEST(CompilerInfo, LanguageVersion) {

--- a/google/cloud/functions/internal/framework_impl_test.cc
+++ b/google/cloud/functions/internal/framework_impl_test.cc
@@ -114,7 +114,8 @@ TEST(FrameworkTest, Http) {
         argc, argv, std::move(f), [&shutdown]() { return shutdown.load(); },
         [&port_p](int port) mutable { port_p.set_value(port); });
   };
-  auto done = std::async(std::launch::async, run, kTestArgc, kTestArgv, hello);
+  auto done = std::async(std::launch::async, run, static_cast<int>(kTestArgc),
+                         kTestArgv, hello);
 
   auto port = port_f.get();
   auto actual = HttpGet("localhost", std::to_string(port), "/say/hello");
@@ -146,7 +147,8 @@ TEST(FrameworkTest, CloudEvent) {
         argc, argv, std::move(f), [&shutdown]() { return shutdown.load(); },
         [&port_p](int port) mutable { port_p.set_value(port); });
   };
-  auto done = std::async(std::launch::async, run, kTestArgc, kTestArgv, hello);
+  auto done = std::async(std::launch::async, run, static_cast<int>(kTestArgc),
+                         kTestArgv, hello);
 
   auto port = port_f.get();
   auto actual = CloudEventGet("localhost", std::to_string(port), "/");
@@ -163,7 +165,8 @@ TEST(FrameworkTest, CloudEvent) {
 
 TEST(FrameworkTest, CloudEventInvalidPort) {
   auto const exit_code = ::google::cloud::functions::Run(
-      kTestInvalidArgc, kTestInvalidArgv, functions::UserCloudEventFunction{});
+      static_cast<int>(kTestInvalidArgc), kTestInvalidArgv,
+      functions::UserCloudEventFunction{});
   EXPECT_NE(exit_code, 0);
 }
 

--- a/google/cloud/functions/internal/setenv.cc
+++ b/google/cloud/functions/internal/setenv.cc
@@ -1,0 +1,56 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/functions/internal/setenv.h"
+#ifdef _WIN32
+// We need _putenv_s()
+#include <stdlib.h>
+#else
+// On Unix-like systems we need setenv()/unsetenv(), which are defined here:
+#include <stdlib.h>  // NOLINT
+#endif               // _WIN32
+
+namespace google::cloud::functions_internal {
+inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+
+namespace {
+void UnsetEnv(char const* variable) {
+#ifdef _WIN32
+  (void)_putenv_s(variable, "");
+#else
+  unsetenv(variable);
+#endif  // _WIN32
+}
+
+void SetEnv(char const* variable, char const* value) {
+#ifdef _WIN32
+  (void)_putenv_s(variable, value);
+#else
+  (void)setenv(variable, value, 1);
+#endif  // _WIN32
+}
+
+}  // namespace
+
+void SetEnv(std::string const& variable,
+            std::optional<std::string> const& value) {
+  if (!value.has_value()) {
+    UnsetEnv(variable.c_str());
+    return;
+  }
+  SetEnv(variable.c_str(), value->c_str());
+}
+
+}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+}  // namespace google::cloud::functions_internal

--- a/google/cloud/functions/internal/setenv.cc
+++ b/google/cloud/functions/internal/setenv.cc
@@ -14,8 +14,8 @@
 
 #include "google/cloud/functions/internal/setenv.h"
 // We need _putenv_s() on WIN32 and setenv()/unsetenv() on Posix. clang-tidy
-// recommends including <cstdlib>. That seems wrong, <cstdlib> is not guaranteed
-// to define the Posix/WIN32 functions.
+// recommends including <cstdlib>. That seems wrong, as <cstdlib> is not
+// guaranteed to define the Posix/WIN32 functions.
 #include <stdlib.h>  // NOLINT(modernize-deprecated-headers)
 
 namespace google::cloud::functions_internal {

--- a/google/cloud/functions/internal/setenv.cc
+++ b/google/cloud/functions/internal/setenv.cc
@@ -13,13 +13,10 @@
 // limitations under the License.
 
 #include "google/cloud/functions/internal/setenv.h"
-#ifdef _WIN32
-// We need _putenv_s()
-#include <stdlib.h>
-#else
-// On Unix-like systems we need setenv()/unsetenv(), which are defined here:
-#include <stdlib.h>  // NOLINT
-#endif               // _WIN32
+// We need _putenv_s() on WIN32 and setenv()/unsetenv() on Posix. clang-tidy
+// recommends including <cstdlib>. That seems wrong, <cstdlib> is not guaranteed
+// to define the Posix/WIN32 functions.
+#include <stdlib.h>  // NOLINT(modernize-deprecated-headers)
 
 namespace google::cloud::functions_internal {
 inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {

--- a/google/cloud/functions/internal/setenv.h
+++ b/google/cloud/functions/internal/setenv.h
@@ -1,0 +1,32 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_SETENV_H
+#define FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_SETENV_H
+
+#include "google/cloud/functions/version.h"
+#include <optional>
+#include <string>
+
+namespace google::cloud::functions_internal {
+inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+
+/// Changes an environment variable in the current process.
+void SetEnv(std::string const& variable,
+            std::optional<std::string> const& value);
+
+}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+}  // namespace google::cloud::functions_internal
+
+#endif  // FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_SETENV_H


### PR DESCRIPTION
Most of the problems were around `setenv()` and `getenv()`, which I
solved by writing a small wrappers. Kept `std::getenv()` in the
examples, because that is most familiar to C++ developers, had to turn
off warnings from MSVC about it though.

Avoid googletest regex because they are unsupported with MSVC

Fix executable paths in integration tests