### PR TITLE
feat: reduce build times and vcpkg binary cache size

### DIFF
--- a/build_scripts/Dockerfile
+++ b/build_scripts/Dockerfile
@@ -68,38 +68,46 @@ RUN curl -sSL https://github.com/Microsoft/vcpkg/archive/65e5ea1df685a5362e70367
     tar -xzf - --strip-components=1 && \
     ./bootstrap-vcpkg.sh -disableMetrics -useSystemBinaries && \
     rm -fr toolsrc/build.rel downloads/*
+# TODO(#249) - for now duplicate this code from /pack/bin/build, this should go away once we
+#   split the "production" vs. "development" builders.
+RUN { \
+    echo 'set(VCPKG_BUILD_TYPE release)'; \
+    echo 'set(VCPKG_CMAKE_SYSTEM_NAME Linux)'; \
+    echo 'set(VCPKG_CRT_LINKAGE dynamic)'; \
+    echo 'set(VCPKG_LIBRARY_LINKAGE static)'; \
+    echo 'set(VCPKG_TARGET_ARCHITECTURE x64)'; \
+} >triplets/x64-linux-nodebug.cmake
 
 WORKDIR /var/cache/vcpkg-cache
 ENV VCPKG_DEFAULT_BINARY_CACHE=/var/cache/vcpkg-cache
 
 # These are needed by the Functions Framework, do them one at a time, easier to
 # rebuild the Docker image if one of them fails to download or something.
-RUN /usr/local/vcpkg/vcpkg install --clean-after-build abseil
-RUN /usr/local/vcpkg/vcpkg install --clean-after-build boost-core
-RUN /usr/local/vcpkg/vcpkg install --clean-after-build openssl
-RUN /usr/local/vcpkg/vcpkg install --clean-after-build boost-program-options
-RUN /usr/local/vcpkg/vcpkg install --clean-after-build boost-asio
-RUN /usr/local/vcpkg/vcpkg install --clean-after-build boost-beast
-RUN /usr/local/vcpkg/vcpkg install --clean-after-build boost-serialization
-RUN /usr/local/vcpkg/vcpkg install --clean-after-build nlohmann-json
+RUN /usr/local/vcpkg/vcpkg install --triplet x64-linux-nodebug abseil
+RUN /usr/local/vcpkg/vcpkg install --triplet x64-linux-nodebug boost-core
+RUN /usr/local/vcpkg/vcpkg install --triplet x64-linux-nodebug openssl
+RUN /usr/local/vcpkg/vcpkg install --triplet x64-linux-nodebug boost-program-options
+RUN /usr/local/vcpkg/vcpkg install --triplet x64-linux-nodebug boost-asio
+RUN /usr/local/vcpkg/vcpkg install --triplet x64-linux-nodebug boost-beast
+RUN /usr/local/vcpkg/vcpkg install --triplet x64-linux-nodebug boost-serialization
+RUN /usr/local/vcpkg/vcpkg install --triplet x64-linux-nodebug nlohmann-json
 
 # The following are not needed by the Functions Framework, but are used often
 # enough that it is a good idea to make them part of the base development
 # environment. Note that this automatically pulls abseil, grpc, protobuf, curl,
 # and a few other libraries.
-RUN /usr/local/vcpkg/vcpkg install --clean-after-build curl
-RUN /usr/local/vcpkg/vcpkg install --clean-after-build protobuf
-RUN /usr/local/vcpkg/vcpkg install --clean-after-build grpc
-RUN /usr/local/vcpkg/vcpkg install --clean-after-build google-cloud-cpp
+RUN /usr/local/vcpkg/vcpkg install --triplet x64-linux-nodebug curl
+RUN /usr/local/vcpkg/vcpkg install --triplet x64-linux-nodebug protobuf
+RUN /usr/local/vcpkg/vcpkg install --triplet x64-linux-nodebug grpc
+RUN /usr/local/vcpkg/vcpkg install --triplet x64-linux-nodebug google-cloud-cpp
 
-# TODO(#41) - switch to the actual vcpkg package once created.
 COPY . /usr/local/share/gcf
 RUN find /usr/local/share/gcf -type f | xargs chmod 644
 RUN find /usr/local/share/gcf -type d | xargs chmod 755
 RUN chmod 755 /usr/local/share/gcf/build_scripts/generate-wrapper.sh
 
-RUN VCPKG_OVERLAY_PORTS=/usr/local/share/gcf/build_scripts/vcpkg-overlays /usr/local/vcpkg/vcpkg install functions-framework-cpp
-RUN /usr/local/vcpkg/vcpkg list | awk '{print $1}' | xargs /usr/local/vcpkg/vcpkg remove --recurse
+RUN VCPKG_OVERLAY_PORTS=/usr/local/share/gcf/build_scripts/vcpkg-overlays \
+    /usr/local/vcpkg/vcpkg install --triplet x64-linux-nodebug functions-framework-cpp
 
 FROM parent AS gcf-cpp-develop
 RUN apt-get update \

--- a/pack/builder.toml
+++ b/pack/builder.toml
@@ -18,7 +18,7 @@ uri = "buildpack"
 [[order]]
     [[order.group]]
     id = "com.google.buildpack.cpp"
-    version = "0.0.1"
+    version = "0.0.2"
 
 # Stack that will be used by the builder
 [stack]

--- a/pack/buildpack/bin/build
+++ b/pack/buildpack/bin/build
@@ -21,6 +21,7 @@ layers="$1"
 
 echo "-----> Setup vcpkg"
 export VCPKG_DEFAULT_BINARY_CACHE="${layers}/vcpkg-cache"
+export VCPKG_DEFAULT_TRIPLET=x64-linux-nodebug
 export VCPKG_OVERLAY_PORTS=/usr/local/share/gcf/build_scripts/vcpkg-overlays
 export VCPKG_ROOT="${layers}/vcpkg"
 
@@ -29,6 +30,13 @@ if [[ ! -d "${VCPKG_ROOT}" ]]; then
   mkdir -p "${VCPKG_ROOT}"
   curl -sSL https://github.com/Microsoft/vcpkg/archive/65e5ea1df685a5362e70367bef4dbf827addff31.tar.gz | \
     tar -C "${VCPKG_ROOT}" -xzf - --strip-components=1
+  cat >"${VCPKG_ROOT}/triplets/x64-linux-nodebug.cmake" <<_EOF_
+set(VCPKG_BUILD_TYPE release)
+set(VCPKG_CMAKE_SYSTEM_NAME Linux)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE static)
+set(VCPKG_TARGET_ARCHITECTURE x64)
+_EOF_
   cp -r /usr/local/bin/vcpkg "${VCPKG_ROOT}"
 cat >"${layers}/vcpkg.toml" <<EOL
 build = true
@@ -47,8 +55,6 @@ launch = false
 EOL
 fi
 
-"${layers}/vcpkg/vcpkg" install functions-framework-cpp
-
 echo "-----> Setup build directory"
 cat >"${layers}/source.toml" <<EOL
 build = true
@@ -59,6 +65,14 @@ EOL
 cp -r /usr/local/share/gcf/build_scripts/cmake "${layers}/source"
 if [[ -r vcpkg.json ]]; then
   cp vcpkg.json "${layers}/source"
+else
+  cat >"${layers}/source/vcpkg.json" <<_EOF_
+{
+  "name": "auto-generated-vcpkg-json",
+  "version-string": "unversioned",
+  "dependencies": [ "functions-framework-cpp" ]
+}
+_EOF_
 fi
 /usr/local/share/gcf/build_scripts/generate-wrapper.sh \
     "${TARGET_FUNCTION}" "${FUNCTION_SIGNATURE_TYPE:-http}" >"${layers}/source/main.cc"
@@ -74,8 +88,8 @@ EOL
   -DCNB_APP_DIR="${PWD}" \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_INSTALL_PREFIX="${layers}/local" \
-  -DCMAKE_TOOLCHAIN_FILE="${layers}/vcpkg/scripts/buildsystems/vcpkg.cmake"
-echo "-----> Compile and Install Function"
+  -DVCPKG_TARGET_TRIPLET="${VCPKG_DEFAULT_TRIPLET}" \
+  -DCMAKE_TOOLCHAIN_FILE="${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
 /usr/local/bin/cmake --build "${layers}/binary" --target install
 
 cat >"${layers}/local.toml" <<EOL

--- a/pack/buildpack/buildpack.toml
+++ b/pack/buildpack/buildpack.toml
@@ -15,7 +15,7 @@ api = "0.2"
 
 [buildpack]
 id = "com.google.buildpack.cpp"
-version = "0.0.1"
+version = "0.0.2"
 name = "Functions Framework C++ Buildpack"
 
 [[stacks]]


### PR DESCRIPTION
Use a custom triplet in vcpkg to only build the release version of our
dependencies. That makes for a faster build, as vcpkg builds both debug
and release by default, and a smaller binary cache (~80MiB vs. ~330MiB).

Fixes #244 helps with #172 