### PR TITLE
chore: update to pack v0.17.0

### DIFF
--- a/build_scripts/pack.Dockerfile
+++ b/build_scripts/pack.Dockerfile
@@ -1,0 +1,21 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM busybox
+ARG PACK_VERSION=v0.17.0
+RUN wget -q -O- https://github.com/buildpacks/pack/releases/download/${PACK_VERSION}/pack-${PACK_VERSION}-linux.tgz | tar zx
+
+FROM gcr.io/distroless/base
+ENTRYPOINT ["/pack"]
+COPY --from=0 /pack /

--- a/ci/README.md
+++ b/ci/README.md
@@ -111,9 +111,9 @@ Create the buildpack builder:
 cd functions-framework-cpp
 docker build -t gcf-cpp-develop -f build_scripts/Dockerfile .
 docker build -t gcf-cpp-runtime --target gcf-cpp-runtime -f build_scripts/Dockerfile build_scripts
-pack create-builder gcf-cpp-builder:bionic --config pack/builder.toml
-pack trust-builder gcf-cpp-builder:bionic
-pack set-default-builder gcf-cpp-builder:bionic
+pack builder create gcf-cpp-builder:bionic --config pack/builder.toml
+pack config trusted-builders add gcf-cpp-builder:bionic
+pack config default-builder gcf-cpp-builder:bionic
 ```
 
 Create containers for the Hello World examples:

--- a/ci/build-examples.yaml
+++ b/ci/build-examples.yaml
@@ -6,26 +6,16 @@ options:
   diskSizeGb: 512
 
 steps:
-  # Create a docker image for the buildpacks `pack` tool
-  - name: 'gcr.io/cloud-builders/git'
-    args: [
-      'clone', '--depth=1',
-      'https://github.com/GoogleCloudPlatform/cloud-builders-community',
-      'third_party/cloud-builders-community',
-    ]
-    waitFor: ['-']
-    id: 'clone-cloud-builders-community'
   # Workaround a kaniko bug using the "edge" builder:
   #     https://github.com/GoogleContainerTools/kaniko/issues/1058
   - name: 'gcr.io/kaniko-project/executor:edge'
     args: [
-        "--context=dir:///workspace/third_party/cloud-builders-community/pack/",
-        "--dockerfile=Dockerfile",
+        "--context=dir:///workspace/build_scripts",
+        "--dockerfile=build_scripts/pack.Dockerfile",
         "--destination=gcr.io/${PROJECT_ID}/pack:${SHORT_SHA}",
         "--cache=true",
         "--cache-ttl=48h"
     ]
-    waitFor: ['clone-cloud-builders-community']
 
   # Create the docker images for the buildpacks builder.
   - name: 'gcr.io/kaniko-project/executor:edge'
@@ -59,11 +49,11 @@ steps:
 
   # Create the buildpacks builder, and make it the default.
   - name: 'gcr.io/${PROJECT_ID}/pack:${SHORT_SHA}'
-    args: ['create-builder', 'gcf-cpp-builder:bionic', '--builder-config', 'pack/builder.toml', ]
+    args: ['builder', 'create', 'gcf-cpp-builder:bionic', '--config', 'pack/builder.toml', ]
   - name: 'gcr.io/${PROJECT_ID}/pack:${SHORT_SHA}'
-    args: ['trust-builder', 'gcf-cpp-builder:bionic', ]
+    args: ['config', 'trusted-builders', 'add', 'gcf-cpp-builder:bionic', ]
   - name: 'gcr.io/${PROJECT_ID}/pack:${SHORT_SHA}'
-    args: ['set-default-builder', 'gcf-cpp-builder:bionic', ]
+    args: ['config', 'default-builder', 'gcf-cpp-builder:bionic', ]
     id: 'gcf-builder-ready'
 
   # Build the examples using the builder. Keep these in alphabetical order.

--- a/examples/README.md
+++ b/examples/README.md
@@ -25,14 +25,14 @@ docker build -t gcf-cpp-runtime --target gcf-cpp-runtime -f build_scripts/Docker
 We use [buildpacks](https://buildpacks.io) to compile the functions into runnable Docker images. First create a builder:
 
 ```sh
-pack create-builder gcf-cpp-builder:bionic --config pack/builder.toml
-pack trust-builder gcf-cpp-builder:bionic
+pack builder create gcf-cpp-builder:bionic --config pack/builder.toml
+pack config trusted-builders add gcf-cpp-builder:bionic
 ```
 
 To avoid using the `--builder gcf-cpp-builder:bionic` option in each command we make this builder the default:
 
 ```sh
-pack set-default-builder gcf-cpp-builder:bionic
+pack config default-builder gcf-cpp-builder:bionic
 ```
 
 ## Creating a Docker image for the examples

--- a/examples/site/howto_create_container/README.md
+++ b/examples/site/howto_create_container/README.md
@@ -24,11 +24,13 @@ If needed, use the [online instructions][docker-install] to download and install
 this tool. This guide assumes that you have configured [sudoless docker], if
 you prefer replace all `docker` commands below with `sudo docker`.
 
-Verify the [pack tool][pack-install] is functional on our workstation:
+Verify the [pack tool][pack-install] is functional on our workstation. These
+instructions were tested with v0.17.0, they should work with newer versions.
+Some commands may not work with older versions.
 
 ```shell
 pack version
-# Output: a version number, e.g., 0.15.1+git-79adc30.build-1660
+# Output: a version number, e.g., 0.17.0+git-d9cb4e7.build-2045
 ```
 
 In this guide we will be using the [HTTP hello word][hello-world-http] function:
@@ -84,9 +86,9 @@ performance.
 ```sh
 docker build -t gcf-cpp-develop -f build_scripts/Dockerfile .
 docker build -t gcf-cpp-runtime --target gcf-cpp-runtime -f build_scripts/Dockerfile build_scripts
-pack create-builder gcf-cpp-builder:bionic --config pack/builder.toml
-pack trust-builder gcf-cpp-builder:bionic
-pack set-default-builder gcf-cpp-builder:bionic
+pack builder create gcf-cpp-builder:bionic --config pack/builder.toml
+pack config trusted-builders add gcf-cpp-builder:bionic
+pack config default-builder gcf-cpp-builder:bionic
 ```
 
 ## Building a Docker image

--- a/examples/site/howto_deploy_cloud_event/README.md
+++ b/examples/site/howto_deploy_cloud_event/README.md
@@ -31,11 +31,14 @@ If needed, use the [online instructions][docker-install] to download and install
 this tool. This guide assumes that you have configured [sudoless docker], if
 you prefer replace all `docker` commands below with `sudo docker`.
 
-Verify the [pack tool][pack-install] is functional on our workstation:
+
+Verify the [pack tool][pack-install] is functional on our workstation. These
+instructions were tested with v0.17.0, they should work with newer versions.
+Some commands may not work with older versions.
 
 ```shell
 pack version
-# Output: a version number, e.g., 0.15.1+git-79adc30.build-1660
+# Output: a version number, e.g., 0.17.0+git-d9cb4e7.build-2045
 ```
 
 In this guide we will be using the [Pub/Sub hello word][hello-world-pubsub] function:
@@ -84,9 +87,9 @@ performance.
 ```sh
 docker build -t gcf-cpp-develop -f build_scripts/Dockerfile .
 docker build -t gcf-cpp-runtime --target gcf-cpp-runtime -f build_scripts/Dockerfile build_scripts
-pack create-builder gcf-cpp-builder:bionic --config pack/builder.toml
-pack trust-builder gcf-cpp-builder:bionic
-pack set-default-builder gcf-cpp-builder:bionic
+pack builder create gcf-cpp-builder:bionic --config pack/builder.toml
+pack config trusted-builders add gcf-cpp-builder:bionic
+pack config default-builder gcf-cpp-builder:bionic
 ```
 
 ## Building a Docker image

--- a/examples/site/howto_deploy_to_cloud_run/README.md
+++ b/examples/site/howto_deploy_to_cloud_run/README.md
@@ -30,11 +30,14 @@ If needed, use the [online instructions][docker-install] to download and install
 this tool. This guide assumes that you have configured [sudoless docker], if
 you prefer replace all `docker` commands below with `sudo docker`.
 
-Verify the [pack tool][pack-install] is functional on our workstation:
+
+Verify the [pack tool][pack-install] is functional on our workstation. These
+instructions were tested with v0.17.0, they should work with newer versions.
+Some commands may not work with older versions.
 
 ```shell
 pack version
-# Output: a version number, e.g., 0.15.1+git-79adc30.build-1660
+# Output: a version number, e.g., 0.17.0+git-d9cb4e7.build-2045
 ```
 
 In this guide we will be using the [HTTP hello word][hello-world-http] function:
@@ -90,9 +93,9 @@ performance.
 ```sh
 docker build -t gcf-cpp-develop -f build_scripts/Dockerfile .
 docker build -t gcf-cpp-runtime --target gcf-cpp-runtime -f build_scripts/Dockerfile build_scripts
-pack create-builder gcf-cpp-builder:bionic --config pack/builder.toml
-pack trust-builder gcf-cpp-builder:bionic
-pack set-default-builder gcf-cpp-builder:bionic
+pack builder create gcf-cpp-builder:bionic --config pack/builder.toml
+pack config trusted-builders add gcf-cpp-builder:bionic
+pack config default-builder gcf-cpp-builder:bionic
 ```
 
 ## Building a Docker image


### PR DESCRIPTION
Use pack v0.17.0 in the CI builds and the examples, this is the current
version and has slightly different syntax for some commands than what we
were showing customers in the how-to guides. Also, I think it makes
sense to run CI with the same version we use for the how-to guides.
