### PR TITLE
ci: cleanup images created during builds

### DIFF
--- a/ci/build-examples.yaml
+++ b/ci/build-examples.yaml
@@ -3,61 +3,64 @@
 timeout: 3600s
 options:
   machineType: 'N1_HIGHCPU_32'
-  diskSizeGb: 512
+  diskSizeGb: '512'
 
 steps:
+  # Generally we prefer to create container images with local names, to avoid
+  # polluting the repository and/or having conflicts with other builds. The
+  # exception are images created by kaniko and any images pushed to GCR
+  # to deploy on Cloud Run.
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', 'pack', '-f', 'build_scripts/pack.Dockerfile', 'build_scripts']
+
   # Workaround a kaniko bug using the "edge" builder:
   #     https://github.com/GoogleContainerTools/kaniko/issues/1058
-  - name: 'gcr.io/kaniko-project/executor:edge'
-    args: [
-        "--context=dir:///workspace/build_scripts",
-        "--dockerfile=build_scripts/pack.Dockerfile",
-        "--destination=gcr.io/${PROJECT_ID}/pack:${SHORT_SHA}",
-        "--cache=true",
-        "--cache-ttl=48h"
-    ]
-
   # Create the docker images for the buildpacks builder.
   - name: 'gcr.io/kaniko-project/executor:edge'
     args: [
         "--context=dir:///workspace/",
         "--dockerfile=build_scripts/Dockerfile",
-        "--destination=gcr.io/${PROJECT_ID}/functions-framework-cpp/runtime:${SHORT_SHA}",
-        "--target=gcf-cpp-runtime",
         "--cache=true",
+        "--cache-repo=gcr.io/${PROJECT_ID}/ci/cache",
+        "--target=gcf-cpp-runtime",
+        "--destination=gcr.io/${PROJECT_ID}/ci/gcf-cpp-runtime:${BUILD_ID}",
     ]
     waitFor: ['-']
     timeout: 1800s
   - name: 'gcr.io/cloud-builders/docker'
-    args: ['pull', 'gcr.io/${PROJECT_ID}/functions-framework-cpp/runtime:${SHORT_SHA}']
+    args: ['pull', 'gcr.io/${PROJECT_ID}/ci/gcf-cpp-runtime:${BUILD_ID}']
+
   - name: 'gcr.io/kaniko-project/executor:edge'
     args: [
         "--context=dir:///workspace/",
         "--dockerfile=build_scripts/Dockerfile",
-        "--destination=gcr.io/${PROJECT_ID}/functions-framework-cpp/develop:${SHORT_SHA}",
         "--cache=true",
+        "--cache-repo=gcr.io/${PROJECT_ID}/ci/cache",
+        "--target=gcf-cpp-develop",
+        "--destination=gcr.io/${PROJECT_ID}/ci/gcf-cpp-develop:${BUILD_ID}",
     ]
     waitFor: ['-']
     timeout: 1800s
   - name: 'gcr.io/cloud-builders/docker'
-    args: ['pull', 'gcr.io/${PROJECT_ID}/functions-framework-cpp/develop:${SHORT_SHA}']
+    args: ['pull', 'gcr.io/${PROJECT_ID}/ci/gcf-cpp-develop:${BUILD_ID}']
+
     # Setup local names for the builder images.
   - name: 'gcr.io/cloud-builders/docker'
-    args: ['tag', 'gcr.io/${PROJECT_ID}/functions-framework-cpp/develop:${SHORT_SHA}', 'gcf-cpp-develop']
+    args: ['tag', 'gcr.io/${PROJECT_ID}/ci/gcf-cpp-develop:${BUILD_ID}', 'gcf-cpp-develop:latest']
   - name: 'gcr.io/cloud-builders/docker'
-    args: ['tag', 'gcr.io/${PROJECT_ID}/functions-framework-cpp/runtime:${SHORT_SHA}', 'gcf-cpp-runtime']
+    args: ['tag', 'gcr.io/${PROJECT_ID}/ci/gcf-cpp-runtime:${BUILD_ID}', 'gcf-cpp-runtime:latest']
 
   # Create the buildpacks builder, and make it the default.
-  - name: 'gcr.io/${PROJECT_ID}/pack:${SHORT_SHA}'
+  - name: 'pack'
     args: ['builder', 'create', 'gcf-cpp-builder:bionic', '--config', 'pack/builder.toml', ]
-  - name: 'gcr.io/${PROJECT_ID}/pack:${SHORT_SHA}'
+  - name: 'pack'
     args: ['config', 'trusted-builders', 'add', 'gcf-cpp-builder:bionic', ]
-  - name: 'gcr.io/${PROJECT_ID}/pack:${SHORT_SHA}'
+  - name: 'pack'
     args: ['config', 'default-builder', 'gcf-cpp-builder:bionic', ]
     id: 'gcf-builder-ready'
 
   # Build the examples using the builder. Keep these in alphabetical order.
-  - name: 'gcr.io/${PROJECT_ID}/pack:${SHORT_SHA}'
+  - name: 'pack'
     waitFor: ['gcf-builder-ready']
     id: 'hello-cloud-event'
     args: ['build',
@@ -67,7 +70,7 @@ steps:
       'hello-cloud-event',
     ]
 
-  - name: 'gcr.io/${PROJECT_ID}/pack:${SHORT_SHA}'
+  - name: 'pack'
     waitFor: ['gcf-builder-ready']
     id: 'hello-from-namespace'
     args: ['build',
@@ -77,7 +80,7 @@ steps:
       'hello-from-namespace',
     ]
 
-  - name: 'gcr.io/${PROJECT_ID}/pack:${SHORT_SHA}'
+  - name: 'pack'
     waitFor: ['gcf-builder-ready']
     id: 'hello-from-namespace-rooted'
     args: ['build',
@@ -87,7 +90,7 @@ steps:
       'hello-from-namespace-rooted',
     ]
 
-  - name: 'gcr.io/${PROJECT_ID}/pack:${SHORT_SHA}'
+  - name: 'pack'
     waitFor: ['gcf-builder-ready']
     id: 'hello-from-nested-namespace'
     args: ['build',
@@ -97,7 +100,7 @@ steps:
       'hello-from-nested-namespace',
     ]
 
-  - name: 'gcr.io/${PROJECT_ID}/pack:${SHORT_SHA}'
+  - name: 'pack'
     waitFor: ['gcf-builder-ready']
     id: 'hello-multiple-sources'
     args: ['build',
@@ -107,7 +110,7 @@ steps:
       'hello-multiple-sources',
     ]
 
-  - name: 'gcr.io/${PROJECT_ID}/pack:${SHORT_SHA}'
+  - name: 'pack'
     waitFor: ['gcf-builder-ready']
     id: 'hello-gcs'
     args: ['build',
@@ -117,7 +120,7 @@ steps:
       'hello-gcs',
     ]
 
-  - name: 'gcr.io/${PROJECT_ID}/pack:${SHORT_SHA}'
+  - name: 'pack'
     waitFor: ['gcf-builder-ready']
     id: 'hello-with-third-party'
     args: ['build',
@@ -127,7 +130,7 @@ steps:
       'hello-with-third-party',
     ]
 
-  - name: 'gcr.io/${PROJECT_ID}/pack:${SHORT_SHA}'
+  - name: 'pack'
     waitFor: ['gcf-builder-ready']
     id: 'hello-world'
     args: ['build',
@@ -137,7 +140,7 @@ steps:
       'hello-world',
     ]
 
-  - name: 'gcr.io/${PROJECT_ID}/pack:${SHORT_SHA}'
+  - name: 'pack'
     waitFor: ['gcf-builder-ready']
     id: 'hello-world-rooted'
     args: ['build',
@@ -148,7 +151,7 @@ steps:
     ]
 
   # Build the cloud site examples.
-  - name: 'gcr.io/${PROJECT_ID}/pack:${SHORT_SHA}'
+  - name: 'pack'
     waitFor: ['gcf-builder-ready']
     id: 'site-concepts_after_response'
     args: ['build',
@@ -157,7 +160,7 @@ steps:
       '--path', 'examples/site/concepts_after_response',
       'site-concepts_after_response',
     ]
-  - name: 'gcr.io/${PROJECT_ID}/pack:${SHORT_SHA}'
+  - name: 'pack'
     waitFor: ['gcf-builder-ready']
     id: 'site-concepts_after_timeout'
     args: ['build',
@@ -166,7 +169,7 @@ steps:
       '--path', 'examples/site/concepts_after_timeout',
       'site-concepts_after_timeout',
     ]
-  - name: 'gcr.io/${PROJECT_ID}/pack:${SHORT_SHA}'
+  - name: 'pack'
     waitFor: ['gcf-builder-ready']
     id: 'site-concepts_filesystem'
     args: ['build',
@@ -175,7 +178,7 @@ steps:
       '--path', 'examples/site/concepts_filesystem',
       'site-concepts_filesystem',
     ]
-  - name: 'gcr.io/${PROJECT_ID}/pack:${SHORT_SHA}'
+  - name: 'pack'
     waitFor: ['gcf-builder-ready']
     id: 'site-concepts_request'
     args: ['build',
@@ -184,7 +187,7 @@ steps:
       '--path', 'examples/site/concepts_request',
       'site-concepts_request',
     ]
-  - name: 'gcr.io/${PROJECT_ID}/pack:${SHORT_SHA}'
+  - name: 'pack'
     waitFor: ['gcf-builder-ready']
     id: 'site-concepts_stateless'
     args: ['build',
@@ -193,7 +196,7 @@ steps:
       '--path', 'examples/site/concepts_stateless',
       'site-concepts_stateless',
     ]
-  - name: 'gcr.io/${PROJECT_ID}/pack:${SHORT_SHA}'
+  - name: 'pack'
     waitFor: ['gcf-builder-ready']
     id: 'site-env_vars'
     args: ['build',
@@ -202,7 +205,7 @@ steps:
       '--path', 'examples/site/env_vars',
       'site-env_vars',
     ]
-  - name: 'gcr.io/${PROJECT_ID}/pack:${SHORT_SHA}'
+  - name: 'pack'
     waitFor: ['gcf-builder-ready']
     id: 'site-hello_world_get'
     args: ['build',
@@ -211,7 +214,7 @@ steps:
       '--path', 'examples/site/hello_world_get',
       'site-hello_world_get',
     ]
-  - name: 'gcr.io/${PROJECT_ID}/pack:${SHORT_SHA}'
+  - name: 'pack'
     waitFor: ['gcf-builder-ready']
     id: 'site-hello_world_http'
     args: ['build',
@@ -220,7 +223,7 @@ steps:
       '--path', 'examples/site/hello_world_http',
       'site-hello_world_http',
     ]
-  - name: 'gcr.io/${PROJECT_ID}/pack:${SHORT_SHA}'
+  - name: 'pack'
     waitFor: ['gcf-builder-ready']
     id: 'site-hello_world_pubsub'
     args: ['build',
@@ -229,7 +232,7 @@ steps:
       '--path', 'examples/site/hello_world_pubsub',
       'site-hello_world_pubsub',
     ]
-  - name: 'gcr.io/${PROJECT_ID}/pack:${SHORT_SHA}'
+  - name: 'pack'
     waitFor: ['gcf-builder-ready']
     id: 'site-hello_world_storage'
     args: ['build',
@@ -238,7 +241,7 @@ steps:
       '--path', 'examples/site/hello_world_storage',
       'site-hello_world_storage',
     ]
-  - name: 'gcr.io/${PROJECT_ID}/pack:${SHORT_SHA}'
+  - name: 'pack'
     waitFor: ['gcf-builder-ready']
     id: 'site-http_content'
     args: ['build',
@@ -247,7 +250,7 @@ steps:
       '--path', 'examples/site/http_content',
       'site-http_content',
     ]
-  - name: 'gcr.io/${PROJECT_ID}/pack:${SHORT_SHA}'
+  - name: 'pack'
     waitFor: ['gcf-builder-ready']
     id: 'site-http_cors'
     args: ['build',
@@ -256,7 +259,7 @@ steps:
       '--path', 'examples/site/http_cors',
       'site-http_cors',
     ]
-  - name: 'gcr.io/${PROJECT_ID}/pack:${SHORT_SHA}'
+  - name: 'pack'
     waitFor: ['gcf-builder-ready']
     id: 'site-http_cors_auth'
     args: ['build',
@@ -265,7 +268,7 @@ steps:
       '--path', 'examples/site/http_cors_auth',
       'site-http_cors_auth',
     ]
-  - name: 'gcr.io/${PROJECT_ID}/pack:${SHORT_SHA}'
+  - name: 'pack'
     waitFor: ['gcf-builder-ready']
     id: 'site-http_method'
     args: ['build',
@@ -274,7 +277,7 @@ steps:
       '--path', 'examples/site/http_method',
       'site-http_method',
     ]
-  - name: 'gcr.io/${PROJECT_ID}/pack:${SHORT_SHA}'
+  - name: 'pack'
     waitFor: ['gcf-builder-ready']
     id: 'site-http_xml'
     args: ['build',
@@ -283,7 +286,7 @@ steps:
       '--path', 'examples/site/http_xml',
       'site-http_xml',
     ]
-  - name: 'gcr.io/${PROJECT_ID}/pack:${SHORT_SHA}'
+  - name: 'pack'
     waitFor: ['gcf-builder-ready']
     id: 'site-pubsub_subscribe'
     args: ['build',
@@ -292,7 +295,7 @@ steps:
       '--path', 'examples/site/pubsub_subscribe',
       'site-pubsub_subscribe',
     ]
-  - name: 'gcr.io/${PROJECT_ID}/pack:${SHORT_SHA}'
+  - name: 'pack'
     waitFor: ['gcf-builder-ready']
     id: 'site-tips_gcp_apis'
     args: ['build',
@@ -301,7 +304,7 @@ steps:
       '--path', 'examples/site/tips_gcp_apis',
       'site-tips_gcp_apis',
     ]
-  - name: 'gcr.io/${PROJECT_ID}/pack:${SHORT_SHA}'
+  - name: 'pack'
     waitFor: ['gcf-builder-ready']
     id: 'site-tips_infinite_retries'
     args: ['build',
@@ -310,7 +313,7 @@ steps:
       '--path', 'examples/site/tips_infinite_retries',
       'site-tips_infinite_retries',
     ]
-  - name: 'gcr.io/${PROJECT_ID}/pack:${SHORT_SHA}'
+  - name: 'pack'
     waitFor: ['gcf-builder-ready']
     id: 'site-tips_lazy_globals'
     args: ['build',
@@ -319,7 +322,7 @@ steps:
       '--path', 'examples/site/tips_lazy_globals',
       'site-tips_lazy_globals',
     ]
-  - name: 'gcr.io/${PROJECT_ID}/pack:${SHORT_SHA}'
+  - name: 'pack'
     waitFor: ['gcf-builder-ready']
     id: 'site-tips_retry'
     args: ['build',
@@ -328,7 +331,7 @@ steps:
       '--path', 'examples/site/tips_retry',
       'site-tips_retry',
     ]
-  - name: 'gcr.io/${PROJECT_ID}/pack:${SHORT_SHA}'
+  - name: 'pack'
     waitFor: ['gcf-builder-ready']
     id: 'site-tips_scopes'
     args: ['build',
@@ -337,7 +340,7 @@ steps:
       '--path', 'examples/site/tips_scopes',
       'site-tips_scopes',
     ]
-  - name: 'gcr.io/${PROJECT_ID}/pack:${SHORT_SHA}'
+  - name: 'pack'
     waitFor: ['gcf-builder-ready']
     id: 'site-tutorial_cloud_bigtable'
     args: ['build',
@@ -346,7 +349,7 @@ steps:
       '--path', 'examples/site/tutorial_cloud_bigtable',
       'site-tutorial_cloud_bigtable',
     ]
-  - name: 'gcr.io/${PROJECT_ID}/pack:${SHORT_SHA}'
+  - name: 'pack'
     waitFor: ['gcf-builder-ready']
     id: 'site-tutorial_cloud_spanner'
     args: ['build',
@@ -359,9 +362,9 @@ steps:
   # Verify generated images are deployable
   - name: 'gcr.io/cloud-builders/docker'
     waitFor: ['hello-world']
-    args: ['tag', 'hello-world', 'gcr.io/${PROJECT_ID}/hello-world-${BUILD_ID}:latest']
+    args: ['tag', 'hello-world', 'gcr.io/${PROJECT_ID}/ci/hello-world:${BUILD_ID}']
   - name: 'gcr.io/cloud-builders/docker'
-    args: ['push', 'gcr.io/${PROJECT_ID}/hello-world-${BUILD_ID}:latest']
+    args: ['push', 'gcr.io/${PROJECT_ID}/ci/hello-world:${BUILD_ID}']
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     entrypoint: 'gcloud'
     args: [
@@ -370,7 +373,7 @@ steps:
       '--platform', 'managed',
       '--project', '${PROJECT_ID}',
       '--region', 'us-central1',
-      '--image', 'gcr.io/${PROJECT_ID}/hello-world-${BUILD_ID}:latest',
+      '--image', 'gcr.io/${PROJECT_ID}/ci/hello-world:${BUILD_ID}',
       '--allow-unauthenticated',
     ]
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
@@ -395,3 +398,34 @@ steps:
       '--region', 'us-central1',
       '--quiet',
     ]
+
+  # Remove the images created by this build.
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        set +e
+        gcloud container images delete -q gcr.io/${PROJECT_ID}/ci/gcf-cpp-runtime:${BUILD_ID}
+        gcloud container images delete -q gcr.io/${PROJECT_ID}/ci/gcf-cpp-develop:${BUILD_ID}
+        gcloud container images delete -q gcr.io/${PROJECT_ID}/ci/hello-world:${BUILD_ID}
+        exit 0
+
+  # The previous step may not run if the build fails. Garbage collect any
+  # images created by this script more than 4 weeks ago. This step should
+  # not break the build on error, and it can start running as soon as the
+  # build does.
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    waitFor: ['-']
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        set +e
+        for image in hello-world gcf-cpp-runtime gcf-cpp-develop cache; do
+          gcloud --project=${PROJECT_ID} container images list-tags gcr.io/${PROJECT_ID}/ci/$${image} \
+              --format='get(digest)' --filter='timestamp.datetime < -P4W' | \
+          xargs printf "gcr.io/${PROJECT_ID}/$${image}@$$1\n"
+        done | \
+        xargs -P 4 -L 32 gcloud container images delete -q --force-delete-tags
+        exit 0


### PR DESCRIPTION
This change reduces the number of images pushed to Google Container
Registry, and removes the images created during the build.

If the build crashes, the cleanup step does not get to run, so as early
as possible a background step (one that has no dependencies in the
build and always succeeds) finds any images older than 4 weeks and
deletes them.
