### PR TITLE
cleanup: split CI vs. developer builders

### DIFF
--- a/build_scripts/Dockerfile
+++ b/build_scripts/Dockerfile
@@ -48,13 +48,21 @@ FROM parent AS gcf-cpp-runtime
 ENV PORT 8080
 USER cnb
 
-FROM parent AS gcf-cpp-incremental
+# Install the system tools needed to compile C++. This needs to go into the
+# `build-image` of the buildpack.
+FROM parent AS gcf-cpp-incremental-0
 RUN apt-get update \
     && apt install -y  --no-install-recommends \
        build-essential g++-8 gcc-8 git libstdc++-8-dev pkg-config tar unzip zip \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 100 \
     && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 100
+
+# Install cmake, ninja and vcpkg. The first two are build systems for C++, the
+# latter is the package manager we use. In an open source builder these would
+# get downloaded dynamically, for builders created by the user they can be
+# part of the builder to speed up the first build of each function.
+FROM gcf-cpp-incremental-0 AS gcf-cpp-incremental-1
 
 WORKDIR /usr/local
 RUN curl -sSL https://github.com/Kitware/CMake/releases/download/v3.19.4/cmake-3.19.4-Linux-x86_64.tar.gz | \
@@ -63,6 +71,7 @@ RUN curl -sSL https://github.com/Kitware/CMake/releases/download/v3.19.4/cmake-3
 RUN curl -sSL https://github.com/ninja-build/ninja/releases/download/v1.10.2/ninja-linux.zip | \
     funzip >/usr/local/bin/ninja && \
     chmod 755 /usr/local/bin/ninja
+
 WORKDIR /usr/local/vcpkg
 RUN curl -sSL https://github.com/Microsoft/vcpkg/archive/65e5ea1df685a5362e70367bef4dbf827addff31.tar.gz | \
     tar -xzf - --strip-components=1 && \
@@ -78,8 +87,12 @@ RUN { \
     echo 'set(VCPKG_TARGET_ARCHITECTURE x64)'; \
 } >triplets/x64-linux-nodebug.cmake
 
+# Warm up the vcpkg cache with all the dependencies for `functions-framework-cpp` and some
+# commonly use packages, like `google-cloud-cpp`.
 WORKDIR /var/cache/vcpkg-cache
 ENV VCPKG_DEFAULT_BINARY_CACHE=/var/cache/vcpkg-cache
+
+FROM gcf-cpp-incremental-1 AS gcf-cpp-incremental-2
 
 # These are needed by the Functions Framework, do them one at a time, easier to
 # rebuild the Docker image if one of them fails to download or something.
@@ -101,27 +114,60 @@ RUN /usr/local/vcpkg/vcpkg install --triplet x64-linux-nodebug protobuf
 RUN /usr/local/vcpkg/vcpkg install --triplet x64-linux-nodebug grpc
 RUN /usr/local/vcpkg/vcpkg install --triplet x64-linux-nodebug google-cloud-cpp
 
+# Warmup the vcpkg cache for `functions-framework-cpp` using the release version
+# of the framework, this is the recommended path for users of the framework.
+FROM gcf-cpp-incremental-2 AS gcf-cpp-incremental-3
+
+RUN /usr/local/vcpkg/vcpkg install --triplet x64-linux-nodebug functions-framework-cpp
+
+# This is the development image we recommend users create in their workstation.
+# It includes all the development tools, including cmake, ninja and vcpkg, as
+# well as binary caches for the latest release of `functions-framework-cpp` and
+# its dependencies, as well as for `google-cloud-cpp`.
+FROM gcf-cpp-incremental-1 AS gcf-cpp-develop
+
+# Copy the framework to /usr/local/share/gcf, that is just a lazy way to
+# get all the scripts we need for both the CI and regular builds.
 COPY . /usr/local/share/gcf
 RUN find /usr/local/share/gcf -type f | xargs chmod 644
 RUN find /usr/local/share/gcf -type d | xargs chmod 755
 RUN chmod 755 /usr/local/share/gcf/build_scripts/generate-wrapper.sh
 
+COPY --from=gcf-cpp-incremental-3 /usr/local/bin/cmake   /usr/local/bin/cmake
+COPY --from=gcf-cpp-incremental-3 /usr/local/bin/ctest   /usr/local/bin/ctest
+COPY --from=gcf-cpp-incremental-3 /usr/local/bin/ninja   /usr/local/bin/ninja
+COPY --from=gcf-cpp-incremental-3 /usr/local/vcpkg/vcpkg /usr/local/bin/vcpkg
+COPY --from=gcf-cpp-incremental-3 /var/cache/vcpkg-cache /var/cache/vcpkg-cache
+
+USER cnb
+
+# Warmup the vcpkg cache for `functions-framework-cpp` using the *current*
+# version of the framework, this is used in the CI build.
+FROM gcf-cpp-incremental-2 AS gcf-cpp-ci-0
+
+COPY . /usr/local/share/gcf
+RUN find /usr/local/share/gcf -type f | xargs chmod 644
+RUN find /usr/local/share/gcf -type d | xargs chmod 755
+RUN chmod 755 /usr/local/share/gcf/build_scripts/generate-wrapper.sh
 RUN VCPKG_OVERLAY_PORTS=/usr/local/share/gcf/build_scripts/vcpkg-overlays \
     /usr/local/vcpkg/vcpkg install --triplet x64-linux-nodebug functions-framework-cpp
 
-FROM parent AS gcf-cpp-develop
-RUN apt-get update \
-    && apt install -y  --no-install-recommends \
-       build-essential g++-8 gcc-8 git libstdc++-8-dev pkg-config tar unzip zip \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
-RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 100 \
-    && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 100
+# This is the image used for the CI builds, includes a binary cache of the
+# *current* version of `functions-framework-cpp`, as well as binary caches of
+# its dependencies and other packages used in the examples.
+FROM gcf-cpp-incremental-1 AS gcf-cpp-ci
 
-COPY --from=gcf-cpp-incremental /usr/local/bin/cmake   /usr/local/bin/cmake
-COPY --from=gcf-cpp-incremental /usr/local/bin/ctest   /usr/local/bin/ctest
-COPY --from=gcf-cpp-incremental /usr/local/bin/ninja   /usr/local/bin/ninja
-COPY --from=gcf-cpp-incremental /usr/local/vcpkg/vcpkg /usr/local/bin/vcpkg
-COPY --from=gcf-cpp-incremental /usr/local/share /usr/local/share
-COPY --from=gcf-cpp-incremental /var/cache/vcpkg-cache /var/cache/vcpkg-cache
+# Copy the framework to /usr/local/share/gcf, that is just a lazy way to
+# get all the scripts we need for both the CI and regular builds.
 
+COPY --from=gcf-cpp-ci-0 /usr/local/bin/cmake   /usr/local/bin/cmake
+COPY --from=gcf-cpp-ci-0 /usr/local/bin/ctest   /usr/local/bin/ctest
+COPY --from=gcf-cpp-ci-0 /usr/local/bin/ninja   /usr/local/bin/ninja
+COPY --from=gcf-cpp-ci-0 /usr/local/vcpkg/vcpkg /usr/local/bin/vcpkg
+COPY --from=gcf-cpp-ci-0 /usr/local/share /usr/local/share
+COPY --from=gcf-cpp-ci-0 /var/cache/vcpkg-cache /var/cache/vcpkg-cache
+
+USER cnb
+
+FROM gcf-cpp-incremental-0 AS gcf-cpp-minimal
 USER cnb

--- a/ci/README.md
+++ b/ci/README.md
@@ -109,9 +109,9 @@ Create the buildpack builder:
 
 ```sh
 cd functions-framework-cpp
-docker build -t gcf-cpp-develop -f build_scripts/Dockerfile .
 docker build -t gcf-cpp-runtime --target gcf-cpp-runtime -f build_scripts/Dockerfile build_scripts
-pack builder create gcf-cpp-builder:bionic --config pack/builder.toml
+docker build -t gcf-cpp-develop --target gcf-cpp-ci -f build_scripts/Dockerfile .
+pack builder create gcf-cpp-builder:bionic --config ci/pack/builder.toml
 pack config trusted-builders add gcf-cpp-builder:bionic
 pack config default-builder gcf-cpp-builder:bionic
 ```

--- a/ci/build-examples.yaml
+++ b/ci/build-examples.yaml
@@ -36,23 +36,23 @@ steps:
         "--dockerfile=build_scripts/Dockerfile",
         "--cache=true",
         "--cache-repo=gcr.io/${PROJECT_ID}/ci/cache",
-        "--target=gcf-cpp-develop",
-        "--destination=gcr.io/${PROJECT_ID}/ci/gcf-cpp-develop:${BUILD_ID}",
+        "--target=gcf-cpp-ci",
+        "--destination=gcr.io/${PROJECT_ID}/ci/gcf-cpp-ci:${BUILD_ID}",
     ]
     waitFor: ['-']
     timeout: 1800s
   - name: 'gcr.io/cloud-builders/docker'
-    args: ['pull', 'gcr.io/${PROJECT_ID}/ci/gcf-cpp-develop:${BUILD_ID}']
+    args: ['pull', 'gcr.io/${PROJECT_ID}/ci/gcf-cpp-ci:${BUILD_ID}']
 
     # Setup local names for the builder images.
   - name: 'gcr.io/cloud-builders/docker'
-    args: ['tag', 'gcr.io/${PROJECT_ID}/ci/gcf-cpp-develop:${BUILD_ID}', 'gcf-cpp-develop:latest']
+    args: ['tag', 'gcr.io/${PROJECT_ID}/ci/gcf-cpp-ci:${BUILD_ID}', 'gcf-cpp-ci:latest']
   - name: 'gcr.io/cloud-builders/docker'
     args: ['tag', 'gcr.io/${PROJECT_ID}/ci/gcf-cpp-runtime:${BUILD_ID}', 'gcf-cpp-runtime:latest']
 
   # Create the buildpacks builder, and make it the default.
   - name: 'pack'
-    args: ['builder', 'create', 'gcf-cpp-builder:bionic', '--config', 'pack/builder.toml', ]
+    args: ['builder', 'create', 'gcf-cpp-builder:bionic', '--config', 'ci/pack/builder.toml', ]
   - name: 'pack'
     args: ['config', 'trusted-builders', 'add', 'gcf-cpp-builder:bionic', ]
   - name: 'pack'
@@ -408,6 +408,7 @@ steps:
         set +e
         gcloud container images delete -q gcr.io/${PROJECT_ID}/ci/gcf-cpp-runtime:${BUILD_ID}
         gcloud container images delete -q gcr.io/${PROJECT_ID}/ci/gcf-cpp-develop:${BUILD_ID}
+        gcloud container images delete -q gcr.io/${PROJECT_ID}/ci/gcf-cpp-ci:${BUILD_ID}
         gcloud container images delete -q gcr.io/${PROJECT_ID}/ci/hello-world:${BUILD_ID}
         exit 0
 
@@ -422,7 +423,7 @@ steps:
       - '-c'
       - |
         set +e
-        for image in hello-world gcf-cpp-runtime gcf-cpp-develop cache; do
+        for image in hello-world gcf-cpp-runtime gcf-cpp-ci gcf-cpp-develop cache; do
           gcloud --project=${PROJECT_ID} container images list-tags gcr.io/${PROJECT_ID}/ci/$${image} \
               --format='get(digest)' --filter='timestamp.datetime < -P4W' | \
           xargs printf "gcr.io/${PROJECT_ID}/$${image}@$$1\n"

--- a/ci/pack/builder.toml
+++ b/ci/pack/builder.toml
@@ -1,0 +1,27 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[[buildpacks]]
+uri = "buildpack"
+
+[[order]]
+    [[order.group]]
+    id = "com.google.buildpack.cpp-ci"
+    version = "0.4.0"
+
+# Stack that will be used by the builder
+[stack]
+id = "google"
+run-image   = "gcf-cpp-runtime:latest"
+build-image = "gcf-cpp-ci:latest"

--- a/ci/pack/buildpack/bin/build
+++ b/ci/pack/buildpack/bin/build
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ layers="$1"
 echo "-----> Setup vcpkg"
 export VCPKG_DEFAULT_BINARY_CACHE="${layers}/vcpkg-cache"
 export VCPKG_DEFAULT_TRIPLET=x64-linux-nodebug
+export VCPKG_OVERLAY_PORTS=/usr/local/share/gcf/build_scripts/vcpkg-overlays
 export VCPKG_ROOT="${layers}/vcpkg"
 
 if [[ ! -d "${VCPKG_ROOT}" ]]; then

--- a/ci/pack/buildpack/bin/detect
+++ b/ci/pack/buildpack/bin/detect
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+if ! (compgen -G "*.cc" >/dev/null ||
+  compgen -G "*.cpp" >/dev/null ||
+  compgen -G "*.cxx" >/dev/null ||
+  [[ ! -f CMakeLists.txt ]]); then
+  exit 100
+fi
+
+exit 0

--- a/ci/pack/buildpack/buildpack.toml
+++ b/ci/pack/buildpack/buildpack.toml
@@ -1,0 +1,22 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+api = "0.2"
+
+[buildpack]
+id = "com.google.buildpack.cpp-ci"
+version = "0.4.0"
+name = "Functions Framework C++ Buildpack for CI Builds"
+
+[[stacks]]
+id = "google"

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,7 +11,7 @@ To compile the examples you will need a Docker image with the development tools 
 To create this image run this command:
 
 ```sh
-docker build -t gcf-cpp-develop -f build_scripts/Dockerfile .
+docker build -t gcf-cpp-develop --target gcf-cpp-develop -f build_scripts/Dockerfile .
 ```
 
 The runtime image is contains just the minimal components to execute a program using the framework:

--- a/examples/site/howto_create_container/README.md
+++ b/examples/site/howto_create_container/README.md
@@ -84,8 +84,8 @@ several minutes, maybe as long as an hour, depending on your workstation's
 performance.
 
 ```sh
-docker build -t gcf-cpp-develop -f build_scripts/Dockerfile .
 docker build -t gcf-cpp-runtime --target gcf-cpp-runtime -f build_scripts/Dockerfile build_scripts
+docker build -t gcf-cpp-develop --target gcf-cpp-develop -f build_scripts/Dockerfile .
 pack builder create gcf-cpp-builder:bionic --config pack/builder.toml
 pack config trusted-builders add gcf-cpp-builder:bionic
 pack config default-builder gcf-cpp-builder:bionic

--- a/examples/site/howto_deploy_cloud_event/README.md
+++ b/examples/site/howto_deploy_cloud_event/README.md
@@ -85,8 +85,8 @@ several minutes, maybe as long as an hour, depending on your workstation's
 performance.
 
 ```sh
-docker build -t gcf-cpp-develop -f build_scripts/Dockerfile .
 docker build -t gcf-cpp-runtime --target gcf-cpp-runtime -f build_scripts/Dockerfile build_scripts
+docker build -t gcf-cpp-develop --target gcf-cpp-develop -f build_scripts/Dockerfile .
 pack builder create gcf-cpp-builder:bionic --config pack/builder.toml
 pack config trusted-builders add gcf-cpp-builder:bionic
 pack config default-builder gcf-cpp-builder:bionic

--- a/examples/site/howto_deploy_to_cloud_run/README.md
+++ b/examples/site/howto_deploy_to_cloud_run/README.md
@@ -91,8 +91,8 @@ several minutes, maybe as long as an hour, depending on your workstation's
 performance.
 
 ```sh
-docker build -t gcf-cpp-develop -f build_scripts/Dockerfile .
 docker build -t gcf-cpp-runtime --target gcf-cpp-runtime -f build_scripts/Dockerfile build_scripts
+docker build -t gcf-cpp-develop --target gcf-cpp-develop -f build_scripts/Dockerfile .
 pack builder create gcf-cpp-builder:bionic --config pack/builder.toml
 pack config trusted-builders add gcf-cpp-builder:bionic
 pack config default-builder gcf-cpp-builder:bionic


### PR DESCRIPTION
In the CI builds we need to test how the *current* version of
`functions-framework-cpp` works with buildback builders. But users of
the framework can use the *released* version of
`functions-framework-cpp`, as this is the version they get for local
development too. This PR splits the two builders, using different images
and buildpacks for each.

Fixes #249 