### PR TITLE
cleanup: simplify Pub/Sub hello world example

### DIFF
--- a/examples/site/hello_world_pubsub/hello_world_pubsub.cc
+++ b/examples/site/hello_world_pubsub/hello_world_pubsub.cc
@@ -17,13 +17,12 @@
 #include <boost/log/trivial.hpp>
 #include <cppcodec/base64_rfc4648.hpp>
 #include <nlohmann/json.hpp>
-#include <iostream>
 
 namespace gcf = ::google::cloud::functions;
 
 void hello_world_pubsub(gcf::CloudEvent event) {  // NOLINT
   if (event.data_content_type().value_or("") != "application/json") {
-    std::cerr << "Error: expected application/json data\n";
+    BOOST_LOG_TRIVIAL(error) << "expected application/json data";
     return;
   }
   auto const payload = nlohmann::json::parse(event.data().value_or("{}"));

--- a/examples/site/hello_world_pubsub/hello_world_pubsub.cc
+++ b/examples/site/hello_world_pubsub/hello_world_pubsub.cc
@@ -14,16 +14,12 @@
 
 // [START functions_helloworld_pubsub]
 #include <google/cloud/functions/cloud_event.h>
-#include <boost/archive/iterators/binary_from_base64.hpp>
-#include <boost/archive/iterators/transform_width.hpp>
 #include <boost/log/trivial.hpp>
+#include <cppcodec/base64_rfc4648.hpp>
 #include <nlohmann/json.hpp>
 #include <iostream>
 
 namespace gcf = ::google::cloud::functions;
-
-// Use Boost.Archive to decode Pub/Sub message payload
-std::string decode_base64(std::string const& base64);
 
 void hello_world_pubsub(gcf::CloudEvent event) {  // NOLINT
   if (event.data_content_type().value_or("") != "application/json") {
@@ -31,32 +27,8 @@ void hello_world_pubsub(gcf::CloudEvent event) {  // NOLINT
     return;
   }
   auto const payload = nlohmann::json::parse(event.data().value_or("{}"));
-  auto name = decode_base64(payload["message"]["data"].get<std::string>());
+  auto const name = cppcodec::base64_rfc4648::decode<std::string>(
+      payload["message"]["data"].get<std::string>());
   BOOST_LOG_TRIVIAL(info) << "Hello " << (name.empty() ? "World" : name);
 }
 // [END functions_helloworld_pubsub]
-
-std::string decode_base64(std::string const& base64) {
-  namespace bai = boost::archive::iterators;
-  auto constexpr kBase64RawBits = 6;
-  auto constexpr kBase64EncodedBits = 8;
-  using Decoder =
-      bai::transform_width<bai::binary_from_base64<std::string::iterator>,
-                           kBase64EncodedBits, kBase64RawBits>;
-  // Pad the raw string if needed.
-  auto padded = base64;
-  padded.append((4 - padded.size() % 4) % 4, '=');
-  // While we know how much padding we added, there may have been some padding
-  // there, just not enough. We need to determine the actual number of `=`
-  // characters at the end of the string.
-  auto pad_count = std::distance(padded.rbegin(),
-                                 std::find_if(padded.rbegin(), padded.rend(),
-                                              [](auto c) { return c != '='; }));
-  if (pad_count > 2) {
-    throw std::invalid_argument("Invalid base64 string <" + base64 + ">");
-  }
-
-  std::string data{Decoder(padded.begin()), Decoder(padded.end())};
-  for (; pad_count != 0; --pad_count) data.pop_back();
-  return data;
-}

--- a/examples/site/hello_world_pubsub/vcpkg.json
+++ b/examples/site/hello_world_pubsub/vcpkg.json
@@ -3,7 +3,7 @@
   "version-string": "unversioned",
   "dependencies": [
     "boost-log",
-    "boost-serialization",
+    "cppcodec",
     "functions-framework-cpp",
     "nlohmann-json"
   ]

--- a/examples/site/howto_deploy_cloud_event/README.md
+++ b/examples/site/howto_deploy_cloud_event/README.md
@@ -43,18 +43,21 @@ pack version
 In this guide we will be using the [Pub/Sub hello word][hello-world-pubsub] function:
 
 ```cc
+#include <google/cloud/functions/cloud_event.h>
+#include <boost/log/trivial.hpp>
+#include <cppcodec/base64_rfc4648.hpp>
+#include <nlohmann/json.hpp>
+
 namespace gcf = ::google::cloud::functions;
 
-// Use Boost.Archive to decode Pub/Sub message payload
-std::string decode_base64(std::string const& base64);
-
-void hello_world_pubsub(gcf::CloudEvent event) {  // NOLINT
+void hello_world_pubsub(gcf::CloudEvent event) {
   if (event.data_content_type().value_or("") != "application/json") {
-    std::cerr << "Error: expected application/json data\n";
+    BOOST_LOG_TRIVIAL(error) << "expected application/json data";
     return;
   }
   auto const payload = nlohmann::json::parse(event.data().value_or("{}"));
-  auto name = decode_base64(payload["message"]["data"].get<std::string>());
+  auto const name = cppcodec::base64_rfc4648::decode<std::string>(
+      payload["message"]["data"].get<std::string>());
   BOOST_LOG_TRIVIAL(info) << "Hello " << (name.empty() ? "World" : name);
 }
 ```

--- a/examples/site/testing_pubsub/README.md
+++ b/examples/site/testing_pubsub/README.md
@@ -21,11 +21,16 @@ We will use this function throughput this guide:
 
 [/examples/site/hello_world_pubsub/hello_world_pubsub.cc]
 ```cc
+#include <google/cloud/functions/cloud_event.h>
+#include <boost/log/trivial.hpp>
+#include <cppcodec/base64_rfc4648.hpp>
+#include <nlohmann/json.hpp>
+
 namespace gcf = ::google::cloud::functions;
 
 void hello_world_pubsub(gcf::CloudEvent event) {
   if (event.data_content_type().value_or("") != "application/json") {
-    std::cerr << "Error: expected application/json data\n";
+    BOOST_LOG_TRIVIAL(error) << "expected application/json data";
     return;
   }
   auto const payload = nlohmann::json::parse(event.data().value_or("{}"));

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -14,6 +14,7 @@
     "boost-property-tree",
     "boost-serialization",
     "boost-uuid",
+    "cppcodec",
     "fmt",
     "google-cloud-cpp",
     "gtest",


### PR DESCRIPTION
Use a simpler library to parse base64 strings, it claims to be not the
most efficient implementation, but seems better for example code. Also
fix some mistakes in the README file.