### PR TITLE
cleanup: remove cruft from hello_world_get

### DIFF
--- a/examples/site/hello_world_get/hello_world_get.cc
+++ b/examples/site/hello_world_get/hello_world_get.cc
@@ -15,7 +15,6 @@
 // [START functions_helloworld_get]
 #include <google/cloud/functions/http_request.h>
 #include <google/cloud/functions/http_response.h>
-#include <nlohmann/json.hpp>
 
 namespace gcf = ::google::cloud::functions;
 

--- a/examples/site/hello_world_get/vcpkg.json
+++ b/examples/site/hello_world_get/vcpkg.json
@@ -1,8 +1,0 @@
-{
-  "name": "hello-world-get",
-  "version-string": "unversioned",
-  "dependencies": [
-    "functions-framework-cpp",
-    "nlohmann-json"
-  ]
-}


### PR DESCRIPTION
It does not use the nlohmann::json library, so we can remove a few
things.