### PR TITLE
cleanup: examples use angle brackets

### DIFF
--- a/examples/cloud_event_examples_test.cc
+++ b/examples/cloud_event_examples_test.cc
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/functions/internal/parse_cloud_event_json.h"
-#include "google/cloud/functions/cloud_event.h"
+#include <google/cloud/functions/internal/parse_cloud_event_json.h>
+#include <google/cloud/functions/cloud_event.h>
 #include <gmock/gmock.h>
 
 namespace gcf = ::google::cloud::functions;

--- a/examples/cloud_event_examples_test.cc
+++ b/examples/cloud_event_examples_test.cc
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <google/cloud/functions/internal/parse_cloud_event_json.h>
-#include <google/cloud/functions/cloud_event.h>
+#include "google/cloud/functions/internal/parse_cloud_event_json.h"
+#include "google/cloud/functions/cloud_event.h"
 #include <gmock/gmock.h>
 
 namespace gcf = ::google::cloud::functions;

--- a/examples/http_examples_test.cc
+++ b/examples/http_examples_test.cc
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/functions/http_request.h"
-#include "google/cloud/functions/http_response.h"
+#include <google/cloud/functions/http_request.h>
+#include <google/cloud/functions/http_response.h>
 #include <gmock/gmock.h>
 
 namespace gcf = ::google::cloud::functions;

--- a/examples/site/testing_http/http_integration_server.cc
+++ b/examples/site/testing_http/http_integration_server.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/functions/framework.h"
+#include <google/cloud/functions/framework.h>
 
 namespace gcf = ::google::cloud::functions;
 extern gcf::HttpResponse hello_world_http(gcf::HttpRequest request);

--- a/examples/site/testing_http/http_unit_test.cc
+++ b/examples/site/testing_http/http_unit_test.cc
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 // [START functions_http_unit_test]
-#include "google/cloud/functions/http_request.h"
-#include "google/cloud/functions/http_response.h"
+#include <google/cloud/functions/http_request.h>
+#include <google/cloud/functions/http_response.h>
 #include <gtest/gtest.h>
 
 namespace gcf = ::google::cloud::functions;


### PR DESCRIPTION
Consistently use `#include <...>` in the examples. Less confusion about
when to use what, and from the target audience (users of the framework),
all the stuff we include is "external".

Fixes #281 