### PR TITLE
cleanup: fix names for some CMake symbols

### DIFF
--- a/cmake/BuildMetadata.cmake
+++ b/cmake/BuildMetadata.cmake
@@ -16,20 +16,21 @@
 
 # Define a function to fetch the current git revision. Using a function creates
 # a new scope, so the CMake variables do not leak to the global namespace.
-function (google_cloud_cpp_initialize_git_head var)
+function (functions_framework_cpp_initialize_git_head var)
     set(result "")
     # If we cannot find a `.git` directory do not even try to guess the git
     # revision.
     if (IS_DIRECTORY ${PROJECT_SOURCE_DIR}/.git)
         set(result "unknown-commit")
         # We need `git` to find the revision.
-        find_program(GOOGLE_CLOUD_CPP_GIT_PROGRAM NAMES git)
-        mark_as_advanced(GOOGLE_CLOUD_CPP_GIT_PROGRAM)
-        if (GOOGLE_CLOUD_CPP_GIT_PROGRAM)
+        find_program(FUNCTIONS_FRAMEWORK_CPP_GIT_PROGRAM NAMES git)
+        mark_as_advanced(FUNCTIONS_FRAMEWORK_CPP_GIT_PROGRAM)
+        if (FUNCTIONS_FRAMEWORK_CPP_GIT_PROGRAM)
             # Run `git rev-parse --short HEAD` and capture the output in a
             # variable.
             execute_process(
-                COMMAND "${GOOGLE_CLOUD_CPP_GIT_PROGRAM}" rev-parse --short HEAD
+                COMMAND "${FUNCTIONS_FRAMEWORK_CPP_GIT_PROGRAM}" rev-parse
+                        --short HEAD
                 OUTPUT_VARIABLE GIT_HEAD_LOG
                 ERROR_VARIABLE GIT_HEAD_LOG)
             string(REPLACE "\n" "" result "${GIT_HEAD_LOG}")
@@ -38,29 +39,28 @@ function (google_cloud_cpp_initialize_git_head var)
     set(${var}
         "${result}"
         PARENT_SCOPE)
+    message(STATUS "functions-framework-cpp build metadata set to ${result}")
 endfunction ()
 
 # Capture the compiler version and the git revision into variables, then
 # generate a config file with the values.
-if (NOT "${GOOGLE_CLOUD_CPP_BUILD_METADATA}" STREQUAL "")
+if (NOT ("${FUNCTIONS_FRAMEWORK_CPP_BUILD_METADATA}" STREQUAL ""))
     # The build metadata flag is already defined, do not re-compute the
     # initialization value. This works both when the user supplies
-    # -DGOOGLE_CLOUD_CPP_METADATA=value in the command line, and when
-    # GOOGLE_CLOUD_CPP_METADATA has a cached value
-    set(GOOGLE_CLOUD_CPP_GIT_HEAD "unused")
+    # -DFUNCTIONS_FRAMEWORK_CPP_METADATA=value in the command line, and when
+    # FUNCTIONS_FRAMEWORK_CPP_METADATA has a cached value
+    set(FUNCTIONS_FRAMEWORK_CPP_GIT_HEAD "unused")
 else ()
-    google_cloud_cpp_initialize_git_head(GOOGLE_CLOUD_CPP_GIT_HEAD)
+    functions_framework_cpp_initialize_git_head(
+        FUNCTIONS_FRAMEWORK_CPP_GIT_HEAD)
 endif ()
 
 # Define a CMake configuration option to set the build metadata. By default this
 # is initialized from `git rev-parse --short HEAD`, but the developer (or the
 # script building via CMake) can override the value.
-set(GOOGLE_CLOUD_CPP_BUILD_METADATA
-    "${GOOGLE_CLOUD_CPP_GIT_HEAD}"
+set(FUNCTIONS_FRAMEWORK_CPP_BUILD_METADATA
+    "${FUNCTIONS_FRAMEWORK_CPP_GIT_HEAD}"
     CACHE STRING "Append build metadata to the library version number")
 # This option is rarely needed. Mark it as "advanced" to remove it from the
 # default CMake UIs.
-mark_as_advanced(GOOGLE_CLOUD_CPP_BUILD_METADATA)
-
-message(STATUS "google-cloud-cpp build metadata set to"
-               " ${GOOGLE_CLOUD_CPP_BUILD_METADATA}")
+mark_as_advanced(FUNCTIONS_FRAMEWORK_CPP_BUILD_METADATA)

--- a/google/cloud/functions/internal/build_info.cc.in
+++ b/google/cloud/functions/internal/build_info.cc.in
@@ -24,16 +24,15 @@ std::string Compiler() {
 }
 
 std::string CompilerFlags() {
-  static char const kCompilerFlags[] =
-      R"""(@CMAKE_CXX_FLAGS@ ${CMAKE_CXX_FLAGS_${GOOGLE_CLOUD_CPP_BUILD_TYPE_UPPER}})""";
+  static char const kCompilerFlags[] = R"""(@CMAKE_CXX_FLAGS@)""";
   return kCompilerFlags;
 }
 
 std::string BuildMetadata() {
-  // Sometimes GOOGLE_CLOUD_CPP_BUILD_METADATA string expands to nothing, and
+  // Sometimes FUNCTIONS_FRAMEWORK_CPP_BUILD_METADATA string expands to nothing, and
   // then clang-tidy complains.
   // NOLINTNEXTLINE(readability-redundant-string-init)
-  static char const kBuildMetadata[] = R"""(@GOOGLE_CLOUD_CPP_BUILD_METADATA@)""";
+  static char const kBuildMetadata[] = R"""(@FUNCTIONS_FRAMEWORK_CPP_BUILD_METADATA@)""";
   return kBuildMetadata;
 }
 


### PR DESCRIPTION
The function, configuration option, and output messages referenced
`google-cloud-cpp`.