### PR TITLE
cleanup: sort the site_test file

### DIFF
--- a/examples/site_test.cc
+++ b/examples/site_test.cc
@@ -243,7 +243,7 @@ TEST(ExamplesSiteTest, HelloWorldPubSub) {
   })js")));
 
   EXPECT_THROW(hello_world_pubsub(
-      google::cloud::functions_internal::ParseCloudEventJson(R"js({
+                   google::cloud::functions_internal::ParseCloudEventJson(R"js({
     "specversion": "1.0",
     "type": "google.cloud.pubsub.topic.v1.messagePublished",
     "source": "//pubsub.googleapis.com/projects/sample-project/topics/gcf-test",


### PR DESCRIPTION
It was getting harder to find the tests in this file, at about 500
lines I do not think it is worthwhile to split it, but keeping the tests
sorted alphabetically should help.