### PR TITLE
feat: make HttpResponse fluent

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,9 @@ using ::google::cloud::functions::HttpRequest;
 using ::google::cloud::functions::HttpResponse;
 
 HttpResponse HelloWorld(HttpRequest) {  // NOLINT
-  HttpResponse response;
-  response.set_header("Content-Type", "text/plain");
-  response.set_payload("Hello World\n");
-  return response;
+  return HttpResponse{}
+      .set_header("Content-Type", "text/plain")
+      .set_payload("Hello World\n");
 }
 ```
 

--- a/examples/hello_from_namespace/hello_from_namespace.cc
+++ b/examples/hello_from_namespace/hello_from_namespace.cc
@@ -21,10 +21,9 @@ using ::google::cloud::functions::HttpRequest;
 using ::google::cloud::functions::HttpResponse;
 
 HttpResponse HelloWorld(HttpRequest) {  // NOLINT
-  HttpResponse response;
-  response.set_header("Content-Type", "text/plain");
-  response.set_payload("Hello from a C++ namespace!\n");
-  return response;
+  return HttpResponse{}
+      .set_header("Content-Type", "text/plain")
+      .set_payload("Hello from a C++ namespace!\n");
 }
 
 }  // namespace hello_from_namespace

--- a/examples/hello_from_nested_namespace/hello_from_nested_namespace.cc
+++ b/examples/hello_from_nested_namespace/hello_from_nested_namespace.cc
@@ -21,10 +21,9 @@ using ::google::cloud::functions::HttpRequest;
 using ::google::cloud::functions::HttpResponse;
 
 HttpResponse HelloWorld(HttpRequest) {  // NOLINT
-  HttpResponse response;
-  response.set_header("Content-Type", "text/plain");
-  response.set_payload("Hello from a nested C++ namespace!\n");
-  return response;
+  return HttpResponse{}
+      .set_header("Content-Type", "text/plain")
+      .set_payload("Hello from a nested C++ namespace!\n");
 }
 
 }  // namespace hello_from_nested_namespace::ns0::ns1

--- a/examples/hello_gcs/hello_gcs.cc
+++ b/examples/hello_gcs/hello_gcs.cc
@@ -23,9 +23,7 @@ namespace gcs = ::google::cloud::storage;
 
 HttpResponse HelloGcs(HttpRequest request) {  // NOLINT
   auto error = [] {
-    HttpResponse response;
-    response.set_result(HttpResponse::kBadRequest);
-    return response;
+    return HttpResponse{}.set_result(HttpResponse::kBadRequest);
   };
 
   std::vector<std::string> components;
@@ -42,8 +40,7 @@ HttpResponse HelloGcs(HttpRequest request) {  // NOLINT
                        std::istreambuf_iterator<char>{});
   if (!reader.status().ok()) return error();
 
-  HttpResponse response;
-  response.set_header("Content-Type", "application/octet-stream");
-  response.set_payload(std::move(contents));
-  return response;
+  return HttpResponse{}
+      .set_header("Content-Type", "application/octet-stream")
+      .set_payload(std::move(contents));
 }

--- a/examples/hello_multiple_sources/hello_multiple_sources.cc
+++ b/examples/hello_multiple_sources/hello_multiple_sources.cc
@@ -20,8 +20,7 @@ using ::google::cloud::functions::HttpRequest;
 using ::google::cloud::functions::HttpResponse;
 
 HttpResponse HelloMultipleSources(HttpRequest) {  // NOLINT
-  HttpResponse response;
-  response.set_header("Content-Type", "text/plain");
-  response.set_payload(Greeting());
-  return response;
+  return HttpResponse{}
+      .set_header("Content-Type", "text/plain")
+      .set_payload(Greeting());
 }

--- a/examples/hello_with_third_party/hello_with_third_party.cc
+++ b/examples/hello_with_third_party/hello_with_third_party.cc
@@ -20,8 +20,7 @@ using ::google::cloud::functions::HttpRequest;
 using ::google::cloud::functions::HttpResponse;
 
 HttpResponse HelloWithThirdParty(HttpRequest request) {  // NOLINT
-  HttpResponse response;
-  response.set_header("Content-Type", "text/plain");
-  response.set_payload(fmt::format("Hello at {}\n", request.target()));
-  return response;
+  return HttpResponse{}
+      .set_header("Content-Type", "text/plain")
+      .set_payload(fmt::format("Hello at {}\n", request.target()));
 }

--- a/examples/hello_world/hello_world.cc
+++ b/examples/hello_world/hello_world.cc
@@ -19,8 +19,7 @@ using ::google::cloud::functions::HttpRequest;
 using ::google::cloud::functions::HttpResponse;
 
 HttpResponse HelloWorld(HttpRequest) {  // NOLINT
-  HttpResponse response;
-  response.set_header("Content-Type", "text/plain");
-  response.set_payload("Hello World\n");
-  return response;
+  return HttpResponse{}
+      .set_header("Content-Type", "text/plain")
+      .set_payload("Hello World\n");
 }

--- a/examples/site/concepts_after_response/concepts_after_response.cc
+++ b/examples/site/concepts_after_response/concepts_after_response.cc
@@ -28,8 +28,6 @@ gcf::HttpResponse concepts_after_response(
     for (int i = 0; i != kIterations; ++i) sum += i;
     return sum;
   });
-  gcf::HttpResponse response;
-  response.set_payload("Hello World!");
-  return response;
+  return gcf::HttpResponse{}.set_payload("Hello World!");
 }
 // [END functions_concepts_after_response]

--- a/examples/site/concepts_after_timeout/concepts_after_timeout.cc
+++ b/examples/site/concepts_after_timeout/concepts_after_timeout.cc
@@ -25,9 +25,7 @@ gcf::HttpResponse concepts_after_timeout(gcf::HttpRequest request) {  // NOLINT
   using std::chrono::minutes;
   std::cout << "Function running..." << std::endl;
   if (request.verb() == "GET") std::this_thread::sleep_for(minutes(2));
-  gcf::HttpResponse response;
-  response.set_payload("Function completed!");
   std::cout << "Function completed!" << std::endl;
-  return response;
+  return gcf::HttpResponse{}.set_payload("Function completed!");
 }
 // [END functions_concepts_after_timeout]

--- a/examples/site/concepts_filesystem/concepts_filesystem.cc
+++ b/examples/site/concepts_filesystem/concepts_filesystem.cc
@@ -25,9 +25,8 @@ gcf::HttpResponse concepts_filesystem(gcf::HttpRequest /*request*/) {  // NOLINT
     payload += p.path().generic_string();
     payload += "\n";
   }
-  gcf::HttpResponse response;
-  response.set_header("content-type", "text/plain");
-  response.set_payload(payload);
-  return response;
+  return gcf::HttpResponse{}
+      .set_header("content-type", "text/plain")
+      .set_payload(payload);
 }
 // [END functions_concepts_after_timeout]

--- a/examples/site/concepts_request/concepts_request.cc
+++ b/examples/site/concepts_request/concepts_request.cc
@@ -27,10 +27,8 @@ unsigned int make_http_request(std::string const& host);
 gcf::HttpResponse concepts_request(gcf::HttpRequest /*request*/) {  // NOLINT
   std::string const host = "example.com";
   auto const code = make_http_request(host);
-  gcf::HttpResponse response;
-  response.set_payload("Received code " + std::to_string(code) + " from " +
-                       host);
-  return response;
+  return gcf::HttpResponse{}.set_payload(
+      "Received code " + std::to_string(code) + " from " + host);
 }
 // [END functions_concepts_requests]
 

--- a/examples/site/concepts_stateless/concepts_stateless.cc
+++ b/examples/site/concepts_stateless/concepts_stateless.cc
@@ -25,8 +25,7 @@ std::atomic<int> count{0};
 }  // namespace
 
 gcf::HttpResponse concepts_stateless(gcf::HttpRequest /*request*/) {  // NOLINT
-  gcf::HttpResponse response;
-  response.set_payload("Instance execution count: " + std::to_string(++count));
-  return response;
+  return gcf::HttpResponse{}.set_payload("Instance execution count: " +
+                                         std::to_string(++count));
 }
 // [END functions_concepts_stateless]

--- a/examples/site/env_vars/env_vars.cc
+++ b/examples/site/env_vars/env_vars.cc
@@ -22,8 +22,6 @@ namespace gcf = ::google::cloud::functions;
 gcf::HttpResponse env_vars(gcf::HttpRequest /*request*/) {  // NOLINT
   char const* value = std::getenv("FOO");
   if (value == nullptr) value = "FOO environment variable is not set";
-  gcf::HttpResponse response;
-  response.set_payload(value);
-  return response;
+  return gcf::HttpResponse{}.set_payload(value);
 }
 // [END functions_env_vars]

--- a/examples/site/hello_world_error/hello_world_error.cc
+++ b/examples/site/hello_world_error/hello_world_error.cc
@@ -50,7 +50,7 @@ gcf::HttpResponse hello_world_error(gcf::HttpRequest request) {  // NOLINT
             << std::endl;
 
   return gcf::HttpResponse{}
-      .set_payload("Hello World!")
-      .set_header("content-type", "text/plain");
+      .set_header("content-type", "text/plain")
+      .set_payload("Hello World!");
 }
 // [END functions_helloworld_error]

--- a/examples/site/hello_world_error/hello_world_error.cc
+++ b/examples/site/hello_world_error/hello_world_error.cc
@@ -23,9 +23,8 @@ namespace gcf = ::google::cloud::functions;
 gcf::HttpResponse hello_world_error(gcf::HttpRequest request) {  // NOLINT
   if (request.target() == "/return500") {
     // An error response code does NOT create entries in Error Reporting
-    gcf::HttpResponse response;
-    response.set_result(gcf::HttpResponse::kInternalServerError);
-    return response;
+    return gcf::HttpResponse{}.set_result(
+        gcf::HttpResponse::kInternalServerError);
   }
   // Unstructured logs to stdout and/or stderr do NOT create entries in Error
   // Reporting
@@ -50,9 +49,8 @@ gcf::HttpResponse hello_world_error(gcf::HttpRequest request) {  // NOLINT
                    .dump()
             << std::endl;
 
-  gcf::HttpResponse response;
-  response.set_payload("Hello World!");
-  response.set_header("content-type", "text/plain");
-  return response;
+  return gcf::HttpResponse{}
+      .set_payload("Hello World!")
+      .set_header("content-type", "text/plain");
 }
 // [END functions_helloworld_error]

--- a/examples/site/hello_world_get/hello_world_get.cc
+++ b/examples/site/hello_world_get/hello_world_get.cc
@@ -20,7 +20,7 @@ namespace gcf = ::google::cloud::functions;
 
 gcf::HttpResponse hello_world_get(gcf::HttpRequest) {  // NOLINT
   return gcf::HttpResponse{}
-      .set_payload("Hello World!")
-      .set_header("content-type", "text/plain");
+      .set_header("content-type", "text/plain")
+      .set_payload("Hello World!");
 }
 // [END functions_helloworld_get]

--- a/examples/site/hello_world_get/hello_world_get.cc
+++ b/examples/site/hello_world_get/hello_world_get.cc
@@ -19,9 +19,8 @@
 namespace gcf = ::google::cloud::functions;
 
 gcf::HttpResponse hello_world_get(gcf::HttpRequest) {  // NOLINT
-  gcf::HttpResponse response;
-  response.set_payload("Hello World!");
-  response.set_header("content-type", "text/plain");
-  return response;
+  return gcf::HttpResponse{}
+      .set_payload("Hello World!")
+      .set_header("content-type", "text/plain");
 }
 // [END functions_helloworld_get]

--- a/examples/site/hello_world_http/hello_world_http.cc
+++ b/examples/site/hello_world_http/hello_world_http.cc
@@ -30,7 +30,7 @@ gcf::HttpResponse hello_world_http(gcf::HttpRequest request) {
   };
 
   return gcf::HttpResponse{}
-      .set_payload(greeting())
-      .set_header("content-type", "text/plain");
+      .set_header("content-type", "text/plain")
+      .set_payload(greeting());
 }
 // [END functions_helloworld_http]

--- a/examples/site/hello_world_http/hello_world_http.cc
+++ b/examples/site/hello_world_http/hello_world_http.cc
@@ -29,9 +29,8 @@ gcf::HttpResponse hello_world_http(gcf::HttpRequest request) {
     return std::string("Hello World!");
   };
 
-  gcf::HttpResponse response;
-  response.set_payload(greeting());
-  response.set_header("content-type", "text/plain");
-  return response;
+  return gcf::HttpResponse{}
+      .set_payload(greeting())
+      .set_header("content-type", "text/plain");
 }
 // [END functions_helloworld_http]

--- a/examples/site/howto_create_container/README.md
+++ b/examples/site/howto_create_container/README.md
@@ -52,10 +52,9 @@ gcf::HttpResponse hello_world_http(gcf::HttpRequest request) {
     return std::string("Hello World!");
   };
 
-  gcf::HttpResponse response;
-  response.set_payload(greeting());
-  response.set_header("content-type", "text/plain");
-  return response;
+  return gcf::HttpResponse{}
+      .set_payload(greeting())
+      .set_header("content-type", "text/plain");
 }
 ```
 

--- a/examples/site/howto_create_container/README.md
+++ b/examples/site/howto_create_container/README.md
@@ -53,8 +53,8 @@ gcf::HttpResponse hello_world_http(gcf::HttpRequest request) {
   };
 
   return gcf::HttpResponse{}
-      .set_payload(greeting())
-      .set_header("content-type", "text/plain");
+      .set_header("content-type", "text/plain")
+      .set_payload(greeting());
 }
 ```
 

--- a/examples/site/howto_deploy_to_cloud_run/README.md
+++ b/examples/site/howto_deploy_to_cloud_run/README.md
@@ -59,8 +59,8 @@ gcf::HttpResponse hello_world_http(gcf::HttpRequest request) {
   };
 
   return gcf::HttpResponse{}
-      .set_payload(greeting())
-      .set_header("content-type", "text/plain");
+      .set_header("content-type", "text/plain")
+      .set_payload(greeting());
 }
 ```
 

--- a/examples/site/howto_deploy_to_cloud_run/README.md
+++ b/examples/site/howto_deploy_to_cloud_run/README.md
@@ -58,10 +58,9 @@ gcf::HttpResponse hello_world_http(gcf::HttpRequest request) {
     return std::string("Hello World!");
   };
 
-  gcf::HttpResponse response;
-  response.set_payload(greeting());
-  response.set_header("content-type", "text/plain");
-  return response;
+  return gcf::HttpResponse{}
+      .set_payload(greeting())
+      .set_header("content-type", "text/plain");
 }
 ```
 

--- a/examples/site/howto_local_development/local_server.cc
+++ b/examples/site/howto_local_development/local_server.cc
@@ -20,10 +20,9 @@ namespace gcf = ::google::cloud::functions;
 namespace {
 
 gcf::HttpResponse HelloWithShutdown(gcf::HttpRequest const& /*request*/) {
-  gcf::HttpResponse response;
-  response.set_header("Content-Type", "text/plain");
-  response.set_payload("Hello World\n");
-  return response;
+  return gcf::HttpResponse{}
+      .set_header("Content-Type", "text/plain")
+      .set_payload("Hello World\n");
 }
 
 }  // namespace

--- a/examples/site/howto_offload_builder_creation/README.md
+++ b/examples/site/howto_offload_builder_creation/README.md
@@ -96,10 +96,9 @@ gcf::HttpResponse hello_world_http(gcf::HttpRequest request) {
     return std::string("Hello World!");
   };
 
-  gcf::HttpResponse response;
-  response.set_payload(greeting());
-  response.set_header("content-type", "text/plain");
-  return response;
+  return gcf::HttpResponse{}
+      .set_payload(greeting())
+      .set_header("content-type", "text/plain");
 }
 ```
 

--- a/examples/site/howto_offload_builder_creation/README.md
+++ b/examples/site/howto_offload_builder_creation/README.md
@@ -97,8 +97,8 @@ gcf::HttpResponse hello_world_http(gcf::HttpRequest request) {
   };
 
   return gcf::HttpResponse{}
-      .set_payload(greeting())
-      .set_header("content-type", "text/plain");
+      .set_header("content-type", "text/plain")
+      .set_payload(greeting());
 }
 ```
 

--- a/examples/site/http_content/http_content.cc
+++ b/examples/site/http_content/http_content.cc
@@ -45,10 +45,9 @@ gcf::HttpResponse http_content(gcf::HttpRequest request) {  // NOLINT
     }
   }
 
-  gcf::HttpResponse response;
-  response.set_payload("Hello " + name);
-  response.set_header("content-type", "text/plain");
-  return response;
+  return gcf::HttpResponse{}
+      .set_payload("Hello " + name)
+      .set_header("content-type", "text/plain");
 }
 // [END functions_http_content]
 

--- a/examples/site/http_content/http_content.cc
+++ b/examples/site/http_content/http_content.cc
@@ -46,8 +46,8 @@ gcf::HttpResponse http_content(gcf::HttpRequest request) {  // NOLINT
   }
 
   return gcf::HttpResponse{}
-      .set_payload("Hello " + name)
-      .set_header("content-type", "text/plain");
+      .set_header("content-type", "text/plain")
+      .set_payload("Hello " + name);
 }
 // [END functions_http_content]
 

--- a/examples/site/http_cors/http_cors.cc
+++ b/examples/site/http_cors/http_cors.cc
@@ -32,8 +32,8 @@ gcf::HttpResponse http_cors(gcf::HttpRequest request) {  // NOLINT
   }
 
   return gcf::HttpResponse{}
+      .set_header("Access-Control-Allow-Origin", "*")
       .set_header("content-type", "text/plain")
-      .set_payload("Hello World!")
-      .set_header("Access-Control-Allow-Origin", "*");
+      .set_payload("Hello World!");
 }
 // [END functions_http_cors]

--- a/examples/site/http_cors/http_cors.cc
+++ b/examples/site/http_cors/http_cors.cc
@@ -23,19 +23,17 @@ gcf::HttpResponse http_cors(gcf::HttpRequest request) {  // NOLINT
   if (request.verb() == "OPTIONS") {
     // Allows GET requests from any origin with the Content-Type header and
     // caches preflight response for an 3600s
-    gcf::HttpResponse response;
-    response.set_result(gcf::HttpResponse::kNoContent);
-    response.set_header("Access-Control-Allow-Origin", "*");
-    response.set_header("Access-Control-Allow-Methods", "GET");
-    response.set_header("Access-Control-Allow-Headers", "Content-Type");
-    response.set_header("Access-Control-Max-Age", "3600");
-    return response;
+    return gcf::HttpResponse{}
+        .set_result(gcf::HttpResponse::kNoContent)
+        .set_header("Access-Control-Allow-Origin", "*")
+        .set_header("Access-Control-Allow-Methods", "GET")
+        .set_header("Access-Control-Allow-Headers", "Content-Type")
+        .set_header("Access-Control-Max-Age", "3600");
   }
 
-  gcf::HttpResponse response;
-  response.set_header("content-type", "text/plain");
-  response.set_payload("Hello World!");
-  response.set_header("Access-Control-Allow-Origin", "*");
-  return response;
+  return gcf::HttpResponse{}
+      .set_header("content-type", "text/plain")
+      .set_payload("Hello World!")
+      .set_header("Access-Control-Allow-Origin", "*");
 }
 // [END functions_http_cors]

--- a/examples/site/http_cors_auth/http_cors_auth.cc
+++ b/examples/site/http_cors_auth/http_cors_auth.cc
@@ -33,9 +33,9 @@ gcf::HttpResponse http_cors_auth(gcf::HttpRequest request) {  // NOLINT
   }
 
   return gcf::HttpResponse{}
-      .set_header("content-type", "text/plain")
-      .set_payload("Hello World!")
       .set_header("Access-Control-Allow-Origin", "https://mydomain.com")
-      .set_header("Access-Control-Allow-Credentials", "true");
+      .set_header("Access-Control-Allow-Credentials", "true")
+      .set_header("content-type", "text/plain")
+      .set_payload("Hello World!");
 }
 // [END functions_http_cors_auth]

--- a/examples/site/http_cors_auth/http_cors_auth.cc
+++ b/examples/site/http_cors_auth/http_cors_auth.cc
@@ -23,21 +23,19 @@ gcf::HttpResponse http_cors_auth(gcf::HttpRequest request) {  // NOLINT
   if (request.verb() == "OPTIONS") {
     // Allows GET requests from any origin with the Content-Type header and
     // caches preflight response for an 3600s
-    gcf::HttpResponse response;
-    response.set_result(gcf::HttpResponse::kNoContent);
-    response.set_header("Access-Control-Allow-Origin", "https://mydomain.com");
-    response.set_header("Access-Control-Allow-Methods", "GET");
-    response.set_header("Access-Control-Allow-Headers", "Authorization");
-    response.set_header("Access-Control-Max-Age", "3600");
-    response.set_header("Access-Control-Allow-Credentials", "true");
-    return response;
+    return gcf::HttpResponse{}
+        .set_result(gcf::HttpResponse::kNoContent)
+        .set_header("Access-Control-Allow-Origin", "https://mydomain.com")
+        .set_header("Access-Control-Allow-Methods", "GET")
+        .set_header("Access-Control-Allow-Headers", "Authorization")
+        .set_header("Access-Control-Max-Age", "3600")
+        .set_header("Access-Control-Allow-Credentials", "true");
   }
 
-  gcf::HttpResponse response;
-  response.set_header("content-type", "text/plain");
-  response.set_payload("Hello World!");
-  response.set_header("Access-Control-Allow-Origin", "https://mydomain.com");
-  response.set_header("Access-Control-Allow-Credentials", "true");
-  return response;
+  return gcf::HttpResponse{}
+      .set_header("content-type", "text/plain")
+      .set_payload("Hello World!")
+      .set_header("Access-Control-Allow-Origin", "https://mydomain.com")
+      .set_header("Access-Control-Allow-Credentials", "true");
 }
 // [END functions_http_cors_auth]

--- a/examples/site/http_method/http_method.cc
+++ b/examples/site/http_method/http_method.cc
@@ -20,16 +20,13 @@ namespace gcf = ::google::cloud::functions;
 
 gcf::HttpResponse http_method(gcf::HttpRequest request) {  // NOLINT
   if (request.verb() == "GET") {
-    gcf::HttpResponse response;
-    response.set_header("content-type", "text/plain");
-    response.set_payload("Hello World!");
-    return response;
+    return gcf::HttpResponse{}
+        .set_header("content-type", "text/plain")
+        .set_payload("Hello World!");
   }
 
-  gcf::HttpResponse response;
-  response.set_result(request.verb() == "POST"
-                          ? gcf::HttpResponse::kForbidden
-                          : gcf::HttpResponse::kMethodNotAllowed);
-  return response;
+  return gcf::HttpResponse{}.set_result(
+      request.verb() == "POST" ? gcf::HttpResponse::kForbidden
+                               : gcf::HttpResponse::kMethodNotAllowed);
 }
 // [END functions_http_method]

--- a/examples/site/http_xml/http_xml.cc
+++ b/examples/site/http_xml/http_xml.cc
@@ -30,9 +30,8 @@ gcf::HttpResponse http_xml(gcf::HttpRequest request) {  // NOLINT
   boost::property_tree::read_xml(is, data);
 
   auto name = data.get<std::string>("name", "World");
-  gcf::HttpResponse response;
-  response.set_header("content-type", "text/plain");
-  response.set_payload("Hello " + name);
-  return response;
+  return gcf::HttpResponse{}
+      .set_header("content-type", "text/plain")
+      .set_payload("Hello " + name);
 }
 // [END functions_http_xml]

--- a/examples/site/log_helloworld/log_helloworld.cc
+++ b/examples/site/log_helloworld/log_helloworld.cc
@@ -28,9 +28,8 @@ gcf::HttpResponse log_helloworld(gcf::HttpRequest /*request*/) {  // NOLINT
                               {"severity", "error"}}
                    .dump()
             << "\n";
-  gcf::HttpResponse response;
-  response.set_payload("Hello Logging!");
-  response.set_header("content-type", "text/plain");
-  return response;
+  return gcf::HttpResponse{}
+      .set_payload("Hello Logging!")
+      .set_header("content-type", "text/plain");
 }
 // [END functions_log_helloworld]

--- a/examples/site/log_helloworld/log_helloworld.cc
+++ b/examples/site/log_helloworld/log_helloworld.cc
@@ -29,7 +29,7 @@ gcf::HttpResponse log_helloworld(gcf::HttpRequest /*request*/) {  // NOLINT
                    .dump()
             << "\n";
   return gcf::HttpResponse{}
-      .set_payload("Hello Logging!")
-      .set_header("content-type", "text/plain");
+      .set_header("content-type", "text/plain")
+      .set_payload("Hello Logging!");
 }
 // [END functions_log_helloworld]

--- a/examples/site/tips_lazy_globals/tips_lazy_globals.cc
+++ b/examples/site/tips_lazy_globals/tips_lazy_globals.cc
@@ -29,8 +29,6 @@ void h_init() { h = "heavy computation"; }
 
 gcf::HttpResponse tips_lazy_globals(gcf::HttpRequest /*request*/) {  // NOLINT
   std::call_once(h_init_flag, h_init);
-  gcf::HttpResponse response;
-  response.set_payload("Global: " + h);
-  return response;
+  return gcf::HttpResponse{}.set_payload("Global: " + h);
 }
 // [END functions_tips_lazy_globals]

--- a/examples/site/tips_scopes/tips_scopes.cc
+++ b/examples/site/tips_scopes/tips_scopes.cc
@@ -29,9 +29,7 @@ std::string h = heavy_computation();
 
 gcf::HttpResponse tips_scopes(gcf::HttpRequest /*request*/) {  // NOLINT
   auto l = light_computation();
-  gcf::HttpResponse response;
-  response.set_payload("Global: " + h + ", Local: " + l);
-  return response;
+  return gcf::HttpResponse{}.set_payload("Global: " + h + ", Local: " + l);
 }
 // [END functions_tips_scopes]
 

--- a/examples/site/tutorial_cloud_bigtable/tutorial_cloud_bigtable.cc
+++ b/examples/site/tutorial_cloud_bigtable/tutorial_cloud_bigtable.cc
@@ -73,9 +73,8 @@ gcf::HttpResponse tutorial_cloud_bigtable(gcf::HttpRequest request) {  // NOLINT
     }
   }
 
-  gcf::HttpResponse response;
-  response.set_payload(std::move(os).str());
-  response.set_header("content-type", "text/plain");
-  return response;
+  return gcf::HttpResponse{}
+      .set_payload(std::move(os).str())
+      .set_header("content-type", "text/plain");
 }
 // [END bigtable_functions_quickstart]

--- a/examples/site/tutorial_cloud_bigtable/tutorial_cloud_bigtable.cc
+++ b/examples/site/tutorial_cloud_bigtable/tutorial_cloud_bigtable.cc
@@ -74,7 +74,7 @@ gcf::HttpResponse tutorial_cloud_bigtable(gcf::HttpRequest request) {  // NOLINT
   }
 
   return gcf::HttpResponse{}
-      .set_payload(std::move(os).str())
-      .set_header("content-type", "text/plain");
+      .set_header("content-type", "text/plain")
+      .set_payload(std::move(os).str());
 }
 // [END bigtable_functions_quickstart]

--- a/examples/site/tutorial_cloud_spanner/tutorial_cloud_spanner.cc
+++ b/examples/site/tutorial_cloud_spanner/tutorial_cloud_spanner.cc
@@ -58,9 +58,8 @@ gcf::HttpResponse tutorial_cloud_spanner(
        << std::get<2>(*row) << "\n";
   }
 
-  gcf::HttpResponse response;
-  response.set_payload(std::move(os).str());
-  response.set_header("content-type", "text/plain");
-  return response;
+  return gcf::HttpResponse{}
+      .set_payload(std::move(os).str())
+      .set_header("content-type", "text/plain");
 }
 // [END spanner_functions_quickstart]

--- a/examples/site/tutorial_cloud_spanner/tutorial_cloud_spanner.cc
+++ b/examples/site/tutorial_cloud_spanner/tutorial_cloud_spanner.cc
@@ -59,7 +59,7 @@ gcf::HttpResponse tutorial_cloud_spanner(
   }
 
   return gcf::HttpResponse{}
-      .set_payload(std::move(os).str())
-      .set_header("content-type", "text/plain");
+      .set_header("content-type", "text/plain")
+      .set_payload(std::move(os).str());
 }
 // [END spanner_functions_quickstart]

--- a/examples/site_test.cc
+++ b/examples/site_test.cc
@@ -318,8 +318,8 @@ TEST(ExamplesSiteTest, HelloWorldStorage) {
 TEST(ExamplesSiteTest, HttpContent) {
   auto make_request = [](std::string content_type, std::string payload) {
     return gcf::HttpRequest{}
-        .set_payload(std::move(payload))
-        .add_header("content-type", std::move(content_type));
+        .add_header("content-type", std::move(content_type))
+        .set_payload(std::move(payload));
   };
 
   auto actual = http_content(

--- a/google/cloud/functions/http_request_test.cc
+++ b/google/cloud/functions/http_request_test.cc
@@ -33,10 +33,10 @@ TEST(HttpRequestTest, Default) {
 
 TEST(HttpRequestTest, SimpleSetters) {
   auto const actual = HttpRequest{}
+                          .set_version(1, 0)
                           .set_verb("POST")
                           .set_target("/index.html")
-                          .set_payload("Hello")
-                          .set_version(1, 0);
+                          .set_payload("Hello");
   EXPECT_EQ(actual.verb(), "POST");
   EXPECT_EQ(actual.target(), "/index.html");
   EXPECT_EQ(actual.payload(), "Hello");

--- a/google/cloud/functions/http_response.h
+++ b/google/cloud/functions/http_response.h
@@ -56,9 +56,7 @@ class HttpResponse {
     impl_->set_result(code);
     return *this;
   }
-  HttpResponse&& set_result(int code) && {
-    return std::move(set_result(code));
-  }
+  HttpResponse&& set_result(int code) && { return std::move(set_result(code)); }
   [[nodiscard]] int result() const { return impl_->result(); }
 
   /// The request HTTP headers

--- a/google/cloud/functions/http_response.h
+++ b/google/cloud/functions/http_response.h
@@ -51,7 +51,7 @@ class HttpResponse {
   }
   [[nodiscard]] std::string const& payload() const { return impl_->payload(); }
 
-  /// Set the status result
+  /// The status result
   HttpResponse& set_result(int code) & {
     impl_->set_result(code);
     return *this;

--- a/google/cloud/functions/http_response.h
+++ b/google/cloud/functions/http_response.h
@@ -41,6 +41,47 @@ class HttpResponse {
 
   HttpResponse();
 
+  /// The request payload
+  HttpResponse& set_payload(std::string v) & {
+    impl_->set_payload(std::move(v));
+    return *this;
+  }
+  HttpResponse&& set_payload(std::string v) && {
+    return std::move(set_payload(std::move(v)));
+  }
+  [[nodiscard]] std::string const& payload() const { return impl_->payload(); }
+
+  /// Set the status result
+  HttpResponse& set_result(int code) & {
+    impl_->set_result(code);
+    return *this;
+  }
+  HttpResponse&& set_result(int code) && {
+    return std::move(set_result(code));
+  }
+  [[nodiscard]] int result() const { return impl_->result(); }
+
+  /// The request HTTP headers
+  HttpResponse& set_header(std::string_view name, std::string_view value) & {
+    impl_->set_header(name, value);
+    return *this;
+  }
+  HttpResponse&& set_header(std::string_view name, std::string_view value) && {
+    return std::move(set_header(name, value));
+  }
+  [[nodiscard]] HeadersType headers() const { return impl_->headers(); }
+
+  /// The HTTP version for the request
+  HttpResponse& set_version(int major, int minor) & {
+    impl_->set_version(major, minor);
+    return *this;
+  }
+  HttpResponse&& set_version(int major, int minor) && {
+    return std::move(set_version(major, minor));
+  }
+  [[nodiscard]] int version_major() const { return impl_->version_major(); }
+  [[nodiscard]] int version_minor() const { return impl_->version_minor(); }
+
   /**
    * @name Common HTTP status codes.
    */
@@ -114,25 +155,6 @@ class HttpResponse {
   inline static auto constexpr kNotExtended = 510;
   inline static auto constexpr kNetworkAuthenticationRequired = 511;
   //@}
-
-  /// The request payload
-  void set_payload(std::string v) { impl_->set_payload(std::move(v)); }
-  [[nodiscard]] std::string const& payload() const { return impl_->payload(); }
-
-  /// Set the status result
-  void set_result(int code) { impl_->set_result(code); }
-  [[nodiscard]] int result() const { return impl_->result(); }
-
-  /// The request HTTP headers
-  void set_header(std::string_view name, std::string_view value) {
-    impl_->set_header(name, value);
-  }
-  [[nodiscard]] HeadersType headers() const { return impl_->headers(); }
-
-  /// The HTTP version for the request
-  void set_version(int major, int minor) { impl_->set_version(major, minor); }
-  [[nodiscard]] int version_major() const { return impl_->version_major(); }
-  [[nodiscard]] int version_minor() const { return impl_->version_minor(); }
 
   class Impl {
    public:

--- a/google/cloud/functions/http_response_test.cc
+++ b/google/cloud/functions/http_response_test.cc
@@ -23,25 +23,29 @@ using ::testing::ElementsAre;
 using ::testing::IsEmpty;
 
 TEST(WrapResponseTest, Payload) {
-  functions::HttpResponse response;
-  EXPECT_THAT(response.payload(), IsEmpty());
+  functions::HttpResponse r;
+  EXPECT_THAT(r.payload(), IsEmpty());
   auto const hello = std::string("Hello");
-  response.set_payload(std::string(hello));
+  auto response = std::move(r).set_payload(std::string(hello));
   EXPECT_EQ(response.payload(), hello);
-  auto const goodbye = std::string("Goodbye");
+  auto const bye = std::string("Goodbye");
+  response.set_payload(bye);
+  EXPECT_EQ(response.payload(), bye);
 }
 
 TEST(WrapResponseTest, Result) {
-  functions::HttpResponse response;
-  EXPECT_EQ(response.result(), functions::HttpResponse::kOkay);
-  response.set_result(functions::HttpResponse::kNotFound);
+  functions::HttpResponse r;
+  EXPECT_EQ(r.result(), functions::HttpResponse::kOkay);
+  auto response = std::move(r).set_result(functions::HttpResponse::kNotFound);
   EXPECT_EQ(response.result(), functions::HttpResponse::kNotFound);
+  response.set_result(functions::HttpResponse::kBadGateway);
+  EXPECT_EQ(response.result(), functions::HttpResponse::kBadGateway);
 }
 
 TEST(WrapResponseTest, Headers) {
-  functions::HttpResponse response;
-  EXPECT_THAT(response.headers(), IsEmpty());
-  response.set_header("Content-Type", "application/json");
+  auto r = functions::HttpResponse{};
+  EXPECT_THAT(r.headers(), IsEmpty());
+  auto response = std::move(r).set_header("Content-Type", "application/json");
   EXPECT_THAT(response.headers(),
               ElementsAre(std::make_pair("Content-Type", "application/json")));
   response.set_header("x-goog-test", "a");
@@ -52,12 +56,15 @@ TEST(WrapResponseTest, Headers) {
 }
 
 TEST(WrapResponseTest, Version) {
-  functions::HttpResponse response;
-  EXPECT_EQ(response.version_major(), 1);
-  EXPECT_EQ(response.version_minor(), 1);
-  response.set_version(1, 0);
+  auto r = functions::HttpResponse{};
+  EXPECT_EQ(r.version_major(), 1);
+  EXPECT_EQ(r.version_minor(), 1);
+  auto response = std::move(r).set_version(1, 0);
   EXPECT_EQ(response.version_major(), 1);
   EXPECT_EQ(response.version_minor(), 0);
+  response.set_version(1, 1);
+  EXPECT_EQ(response.version_major(), 1);
+  EXPECT_EQ(response.version_minor(), 1);
 }
 
 }  // namespace

--- a/google/cloud/functions/integration_tests/echo_server.cc
+++ b/google/cloud/functions/integration_tests/echo_server.cc
@@ -29,17 +29,14 @@ HttpResponse EchoServer(HttpRequest const& request) {
   if (target.rfind("/unknown-exception/", 0) == 0) throw "uh-oh";
 
   if (target == "/ok") {
-    HttpResponse response;
-    response.set_header("Content-Type", "text/plain");
-    response.set_payload("OK");
-    return response;
+    return HttpResponse{}
+        .set_header("Content-Type", "text/plain")
+        .set_payload("OK");
   }
 
   if (target.rfind("/error/", 0) == 0) {
     auto code = std::stoi(target.substr(std::strlen("/error/")));
-    HttpResponse response;
-    response.set_result(code);
-    return response;
+    return HttpResponse{}.set_result(code);
   }
 
   if (target.rfind("/buffered-stdout/", 0) == 0) {
@@ -60,10 +57,9 @@ HttpResponse EchoServer(HttpRequest const& request) {
   }
   payload << "}\n";
 
-  HttpResponse response;
-  response.set_header("Content-Type", "application/json");
-  response.set_payload(std::move(payload).str());
-  return response;
+  return HttpResponse{}
+      .set_header("Content-Type", "application/json")
+      .set_payload(std::move(payload).str());
 }
 
 int main(int argc, char* argv[]) {

--- a/google/cloud/functions/internal/call_user_function_test.cc
+++ b/google/cloud/functions/internal/call_user_function_test.cc
@@ -29,10 +29,9 @@ TEST(CallUserFunctionHttpTest, Basic) {
     EXPECT_EQ(request.target(), "/foo/bar");
     EXPECT_THAT(request.headers(),
                 Contains(std::make_pair("x-goog-test", "test-value")));
-    functions::HttpResponse response{};
-    response.set_payload("just nod if you can hear me");
-    response.set_header("x-goog-test", "response-header");
-    return response;
+    return functions::HttpResponse{}
+        .set_payload("just nod if you can hear me")
+        .set_header("x-goog-test", "response-header");
   };
   BeastRequest request;
   request.target("/foo/bar");
@@ -47,9 +46,8 @@ TEST(CallUserFunctionHttpTest, Basic) {
 
 TEST(CallUserFunctionHttpTest, ReturnError) {
   auto func = [&](functions::HttpRequest const& /*request*/) {
-    functions::HttpResponse response{};
-    response.set_result(functions::HttpResponse::kNotFound);
-    return response;
+    return functions::HttpResponse{}.set_result(
+        functions::HttpResponse::kNotFound);
   };
   BeastRequest request;
   request.target("/foo/bar/not-there");

--- a/google/cloud/functions/internal/call_user_function_test.cc
+++ b/google/cloud/functions/internal/call_user_function_test.cc
@@ -30,8 +30,8 @@ TEST(CallUserFunctionHttpTest, Basic) {
     EXPECT_THAT(request.headers(),
                 Contains(std::make_pair("x-goog-test", "test-value")));
     return functions::HttpResponse{}
-        .set_payload("just nod if you can hear me")
-        .set_header("x-goog-test", "response-header");
+        .set_header("x-goog-test", "response-header")
+        .set_payload("just nod if you can hear me");
   };
   BeastRequest request;
   request.target("/foo/bar");

--- a/google/cloud/functions/internal/framework_impl_test.cc
+++ b/google/cloud/functions/internal/framework_impl_test.cc
@@ -104,8 +104,8 @@ TEST(FrameworkTest, Http) {
   std::atomic<bool> shutdown{false};
   auto hello = [](functions::HttpRequest const& r) {
     return functions::HttpResponse{}
-        .set_payload("Hello World from " + r.target())
-        .set_header("content-type", "text/plain");
+        .set_header("content-type", "text/plain")
+        .set_payload("Hello World from " + r.target());
   };
   auto run = [&](int argc, char const* const argv[],
                  functions::UserHttpFunction f) {

--- a/google/cloud/functions/internal/framework_impl_test.cc
+++ b/google/cloud/functions/internal/framework_impl_test.cc
@@ -103,10 +103,9 @@ TEST(FrameworkTest, Http) {
   auto port_f = port_p.get_future();
   std::atomic<bool> shutdown{false};
   auto hello = [](functions::HttpRequest const& r) {
-    functions::HttpResponse response;
-    response.set_payload("Hello World from " + r.target());
-    response.set_header("content-type", "text/plain");
-    return response;
+    return functions::HttpResponse{}
+        .set_payload("Hello World from " + r.target())
+        .set_header("content-type", "text/plain");
   };
   auto run = [&](int argc, char const* const argv[],
                  functions::UserHttpFunction f) {


### PR DESCRIPTION
In many cases we want to set one or two attributes of a response and
then return it, as in:

```cc
return HttpResponse{}.set_result(HttpResponse::kNotFound);
```

This makes it easy to do so, and changes the examples to take advantage
of this feature.