### PR TITLE
chore: update vcpkg version to include v0.4.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 env:
-  vcpkg_SHA: "65e5ea1df685a5362e70367bef4dbf827addff31"
+  vcpkg_SHA: "4d0234f8ad5db84df218df48224697a1f44f0f49"
   VCPKG_TOOL_VERSION: "2021-01-13-768d8f95c9e752603d2c5901c7a7c7fbdb08af35"
 
 jobs:

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 env:
-  vcpkg_SHA: "65e5ea1df685a5362e70367bef4dbf827addff31"
+  vcpkg_SHA: "4d0234f8ad5db84df218df48224697a1f44f0f49"
 
 jobs:
   coverage:

--- a/.github/workflows/sanitize.yaml
+++ b/.github/workflows/sanitize.yaml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 env:
-  vcpkg_SHA: "65e5ea1df685a5362e70367bef4dbf827addff31"
+  vcpkg_SHA: "4d0234f8ad5db84df218df48224697a1f44f0f49"
 
 jobs:
   sanitized-build:

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 env:
-  vcpkg_SHA: "65e5ea1df685a5362e70367bef4dbf827addff31"
+  vcpkg_SHA: "4d0234f8ad5db84df218df48224697a1f44f0f49"
 
 jobs:
   clang-tidy:

--- a/build_scripts/Dockerfile
+++ b/build_scripts/Dockerfile
@@ -73,7 +73,7 @@ RUN curl -sSL https://github.com/ninja-build/ninja/releases/download/v1.10.2/nin
     chmod 755 /usr/local/bin/ninja
 
 WORKDIR /usr/local/vcpkg
-RUN curl -sSL https://github.com/Microsoft/vcpkg/archive/65e5ea1df685a5362e70367bef4dbf827addff31.tar.gz | \
+RUN curl -sSL https://github.com/Microsoft/vcpkg/archive/4d0234f8ad5db84df218df48224697a1f44f0f49.tar.gz | \
     tar -xzf - --strip-components=1 && \
     ./bootstrap-vcpkg.sh -disableMetrics -useSystemBinaries && \
     rm -fr toolsrc/build.rel downloads/*

--- a/build_scripts/pack/build.in
+++ b/build_scripts/pack/build.in
@@ -16,7 +16,7 @@ fi
 if [[ ! -d "${VCPKG_ROOT}" ]]; then
   echo "-----> Install vcpkg"
   mkdir -p "${VCPKG_ROOT}"
-  curl -sSL https://github.com/Microsoft/vcpkg/archive/65e5ea1df685a5362e70367bef4dbf827addff31.tar.gz | \
+  curl -sSL https://github.com/Microsoft/vcpkg/archive/4d0234f8ad5db84df218df48224697a1f44f0f49.tar.gz | \
     tar -C "${VCPKG_ROOT}" -xzf - --strip-components=1
   cat >"${VCPKG_ROOT}/triplets/x64-linux-nodebug.cmake" <<_EOF_
 set(VCPKG_BUILD_TYPE release)

--- a/ci/pack/buildpack/bin/build
+++ b/ci/pack/buildpack/bin/build
@@ -35,7 +35,7 @@ fi
 if [[ ! -d "${VCPKG_ROOT}" ]]; then
   echo "-----> Install vcpkg"
   mkdir -p "${VCPKG_ROOT}"
-  curl -sSL https://github.com/Microsoft/vcpkg/archive/65e5ea1df685a5362e70367bef4dbf827addff31.tar.gz | \
+  curl -sSL https://github.com/Microsoft/vcpkg/archive/4d0234f8ad5db84df218df48224697a1f44f0f49.tar.gz | \
     tar -C "${VCPKG_ROOT}" -xzf - --strip-components=1
   cat >"${VCPKG_ROOT}/triplets/x64-linux-nodebug.cmake" <<_EOF_
 set(VCPKG_BUILD_TYPE release)

--- a/pack/buildpack/bin/build
+++ b/pack/buildpack/bin/build
@@ -35,7 +35,7 @@ fi
 if [[ ! -d "${VCPKG_ROOT}" ]]; then
   echo "-----> Install vcpkg"
   mkdir -p "${VCPKG_ROOT}"
-  curl -sSL https://github.com/Microsoft/vcpkg/archive/65e5ea1df685a5362e70367bef4dbf827addff31.tar.gz | \
+  curl -sSL https://github.com/Microsoft/vcpkg/archive/4d0234f8ad5db84df218df48224697a1f44f0f49.tar.gz | \
     tar -C "${VCPKG_ROOT}" -xzf - --strip-components=1
   cat >"${VCPKG_ROOT}/triplets/x64-linux-nodebug.cmake" <<_EOF_
 set(VCPKG_BUILD_TYPE release)


### PR DESCRIPTION
Update the vcpkg version to include v0.4.0 of the framework. Some of the
Docker images were still pinned to the "previous release", which caused
build problems.