### PR TITLE
fix: actually handle sessions in parallel

### DIFF
--- a/google/cloud/functions/integration_tests/basic_integration_test.cc
+++ b/google/cloud/functions/integration_tests/basic_integration_test.cc
@@ -20,7 +20,9 @@
 #include <boost/process.hpp>
 #include <gmock/gmock.h>
 #include <nlohmann/json.hpp>
+#include <algorithm>
 #include <chrono>
+#include <future>
 #include <string>
 
 namespace google::cloud::functions_internal {
@@ -28,6 +30,8 @@ inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
 namespace {
 
 using ::testing::HasSubstr;
+using ::testing::Each;
+
 namespace bp = boost::process;
 // Even with C++17, we have to use the Boost version because Boost.Process
 // expects it.
@@ -189,6 +193,35 @@ TEST(RunIntegrationTest, ConformanceSmokeTest) {
   auto server = bp::child(ExePath(kConformanceServer), "--port=8010");
   auto result = WaitForServerReady("localhost", "8010");
   ASSERT_EQ(result, 0);
+
+  try {
+    (void)HttpGet("localhost", "8010", "/quit/program/0");
+  } catch (...) {
+  }
+  server.wait();
+  EXPECT_EQ(server.exit_code(), 0);
+}
+
+TEST(RunIntegrationTest, SomeParallelism) {
+  auto server = bp::child(ExePath(kServer), "--port=8010");
+  auto result = WaitForServerReady("localhost", "8010");
+  ASSERT_EQ(result, 0);
+
+  auto const kTaskCount = 16;
+  auto task = [] {
+    auto start = std::chrono::steady_clock::now();
+    (void)HttpGet("localhost", "8010", "/sleep/1000");
+    return std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - start);
+  };
+  std::vector<std::future<std::chrono::milliseconds>> tasks(kTaskCount);
+  std::generate(tasks.begin(), tasks.end(),
+                [&] { return std::async(std::launch::async, task); });
+  std::vector<std::chrono::milliseconds> elapsed(tasks.size());
+  std::transform(tasks.begin(), tasks.end(), elapsed.begin(),
+                 [](auto& f) { return f.get(); });
+  // We ask for a 1s delay, but we tolerate up to 5.
+  EXPECT_THAT(elapsed, Each(::testing::Le(std::chrono::seconds(5))));
 
   try {
     (void)HttpGet("localhost", "8010", "/quit/program/0");

--- a/google/cloud/functions/integration_tests/basic_integration_test.cc
+++ b/google/cloud/functions/integration_tests/basic_integration_test.cc
@@ -207,7 +207,7 @@ TEST(RunIntegrationTest, SomeParallelism) {
   auto result = WaitForServerReady("localhost", "8010");
   ASSERT_EQ(result, 0);
 
-  auto const kTaskCount = 16;
+  auto constexpr kTaskCount = 16;
   auto task = [] {
     auto start = std::chrono::steady_clock::now();
     (void)HttpGet("localhost", "8010", "/sleep/1000");

--- a/google/cloud/functions/integration_tests/basic_integration_test.cc
+++ b/google/cloud/functions/integration_tests/basic_integration_test.cc
@@ -124,6 +124,7 @@ TEST(RunIntegrationTest, Basic) {
 
   try {
     (void)HttpGet("localhost", "8010", "/quit/program/0");
+    (void)HttpGet("localhost", "8010", "/quit/program/0");
   } catch (...) {
   }
   server.wait();
@@ -151,6 +152,7 @@ TEST(RunIntegrationTest, ExceptionLogsToStderr) {
   EXPECT_THAT(log.value("message", ""), HasSubstr("/exception/test-string"));
 
   try {
+    (void)HttpGet("localhost", "8010", "/quit/program/0");
     (void)HttpGet("localhost", "8010", "/quit/program/0");
   } catch (...) {
   }
@@ -183,6 +185,7 @@ TEST(RunIntegrationTest, OutputIsFlushed) {
 
   try {
     (void)HttpGet("localhost", "8010", "/quit/program/0");
+    (void)HttpGet("localhost", "8010", "/quit/program/0");
   } catch (...) {
   }
   server.wait();
@@ -195,6 +198,7 @@ TEST(RunIntegrationTest, ConformanceSmokeTest) {
   ASSERT_EQ(result, 0);
 
   try {
+    (void)HttpGet("localhost", "8010", "/quit/program/0");
     (void)HttpGet("localhost", "8010", "/quit/program/0");
   } catch (...) {
   }
@@ -224,6 +228,7 @@ TEST(RunIntegrationTest, SomeParallelism) {
   EXPECT_THAT(elapsed, Each(::testing::Le(std::chrono::seconds(5))));
 
   try {
+    (void)HttpGet("localhost", "8010", "/quit/program/0");
     (void)HttpGet("localhost", "8010", "/quit/program/0");
   } catch (...) {
   }

--- a/google/cloud/functions/integration_tests/basic_integration_test.cc
+++ b/google/cloud/functions/integration_tests/basic_integration_test.cc
@@ -29,8 +29,8 @@ namespace google::cloud::functions_internal {
 inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
 namespace {
 
-using ::testing::HasSubstr;
 using ::testing::Each;
+using ::testing::HasSubstr;
 
 namespace bp = boost::process;
 // Even with C++17, we have to use the Boost version because Boost.Process

--- a/google/cloud/functions/integration_tests/cloud_event_conformance.cc
+++ b/google/cloud/functions/integration_tests/cloud_event_conformance.cc
@@ -63,7 +63,6 @@ void CloudEventConformance(functions::CloudEvent const& ev) {
 
 int main(int argc, char* argv[]) {
   return google::cloud::functions_internal::RunForTest(
-      argc, argv, CloudEventConformance,
-      std::function<bool()>{[] { return shutdown_server.load(); }},
-      std::function<void(int)>([](int) {}));
+      argc, argv, CloudEventConformance, [] { return shutdown_server.load(); },
+      [](int /*port*/) {});
 }

--- a/google/cloud/functions/integration_tests/cloud_event_handler.cc
+++ b/google/cloud/functions/integration_tests/cloud_event_handler.cc
@@ -38,7 +38,6 @@ void CloudEventHandler(CloudEvent const& event) {
 
 int main(int argc, char* argv[]) {
   return google::cloud::functions_internal::RunForTest(
-      argc, argv, CloudEventHandler,
-      std::function<bool()>{[] { return shutdown_server.load(); }},
-      std::function<void(int)>([](int) {}));
+      argc, argv, CloudEventHandler, [] { return shutdown_server.load(); },
+      [](int /*port*/) {});
 }

--- a/google/cloud/functions/integration_tests/cloud_event_handler.cc
+++ b/google/cloud/functions/integration_tests/cloud_event_handler.cc
@@ -12,16 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/functions/framework.h"
-#include <cstdlib>
+#include "google/cloud/functions/internal/framework_impl.h"
+#include <atomic>
 #include <iostream>
 
-namespace functions = google::cloud::functions;
 using ::google::cloud::functions::CloudEvent;
+
+std::atomic<bool> shutdown_server{false};
 
 void CloudEventHandler(CloudEvent const& event) {
   auto const& subject = event.subject().value_or("");
-  if (subject == "/quit/program/0") std::exit(0);
+  if (subject == "/quit/program/0") {
+    shutdown_server.store(true);
+    return;
+  }
   if (subject.rfind("/exception/", 0) == 0) throw std::runtime_error(subject);
   if (subject.rfind("/unknown-exception/", 0) == 0) throw "uh-oh";
   if (subject.rfind("/buffered-stdout/", 0) == 0) {
@@ -33,5 +37,8 @@ void CloudEventHandler(CloudEvent const& event) {
 }
 
 int main(int argc, char* argv[]) {
-  return functions::Run(argc, argv, CloudEventHandler);
+  return google::cloud::functions_internal::RunForTest(
+      argc, argv, CloudEventHandler,
+      std::function<bool()>{[] { return shutdown_server.load(); }},
+      std::function<void(int)>([](int) {}));
 }

--- a/google/cloud/functions/integration_tests/cloud_event_integration_test.cc
+++ b/google/cloud/functions/integration_tests/cloud_event_integration_test.cc
@@ -200,6 +200,7 @@ TEST(RunIntegrationTest, Basic) {
 
   try {
     (void)HttpPost("localhost", "8020", "/quit/program/0");
+    (void)HttpPost("localhost", "8020", "/quit/program/0");
   } catch (...) {
   }
   server.wait();
@@ -215,6 +216,7 @@ TEST(RunIntegrationTest, Batch) {
   EXPECT_EQ(actual.result_int(), functions::HttpResponse::kOkay);
   try {
     (void)HttpPost("localhost", "8020", "/quit/program/0");
+    (void)HttpPost("localhost", "8020", "/quit/program/0");
   } catch (...) {
   }
   server.wait();
@@ -229,6 +231,7 @@ TEST(RunIntegrationTest, Binary) {
   auto actual = HttpGetBinary("localhost", "8020");
   EXPECT_EQ(actual.result_int(), functions::HttpResponse::kOkay);
   try {
+    (void)HttpPost("localhost", "8020", "/quit/program/0");
     (void)HttpPost("localhost", "8020", "/quit/program/0");
   } catch (...) {
   }
@@ -257,6 +260,7 @@ TEST(RunIntegrationTest, ExceptionLogsToStderr) {
   EXPECT_THAT(log.value("message", ""), HasSubstr("/exception/test-string"));
 
   try {
+    (void)HttpPost("localhost", "8020", "/quit/program/0");
     (void)HttpPost("localhost", "8020", "/quit/program/0");
   } catch (...) {
   }
@@ -289,6 +293,7 @@ TEST(RunIntegrationTest, OutputIsFlushed) {
 
   try {
     (void)HttpPost("localhost", "8020", "/quit/program/0");
+    (void)HttpPost("localhost", "8020", "/quit/program/0");
   } catch (...) {
   }
   server.wait();
@@ -301,6 +306,7 @@ TEST(RunIntegrationTest, ConformanceSmokeTest) {
   ASSERT_EQ(result, 0);
 
   try {
+    (void)HttpPost("localhost", "8020", "/quit/program/0");
     (void)HttpPost("localhost", "8020", "/quit/program/0");
   } catch (...) {
   }

--- a/google/cloud/functions/integration_tests/echo_server.cc
+++ b/google/cloud/functions/integration_tests/echo_server.cc
@@ -71,7 +71,6 @@ HttpResponse EchoServer(HttpRequest const& request) {
 
 int main(int argc, char* argv[]) {
   return google::cloud::functions_internal::RunForTest(
-      argc, argv, EchoServer,
-      std::function<bool()>{[] { return shutdown_server.load(); }},
-      std::function<void(int)>([](int) {}));
+      argc, argv, EchoServer, [] { return shutdown_server.load(); },
+      [](int /*port*/) {});
 }

--- a/google/cloud/functions/integration_tests/http_conformance.cc
+++ b/google/cloud/functions/integration_tests/http_conformance.cc
@@ -30,7 +30,6 @@ functions::HttpResponse HttpConformance(functions::HttpRequest const& request) {
 
 int main(int argc, char* argv[]) {
   return google::cloud::functions_internal::RunForTest(
-      argc, argv, HttpConformance,
-      std::function<bool()>{[] { return shutdown_server.load(); }},
-      std::function<void(int)>([](int) {}));
+      argc, argv, HttpConformance, [] { return shutdown_server.load(); },
+      [](int /*port*/) {});
 }

--- a/google/cloud/functions/integration_tests/http_conformance.cc
+++ b/google/cloud/functions/integration_tests/http_conformance.cc
@@ -12,18 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/functions/framework.h"
+#include "google/cloud/functions/internal/framework_impl.h"
+#include <atomic>
 #include <fstream>
 
 namespace functions = ::google::cloud::functions;
+
+std::atomic<bool> shutdown_server{false};
+
 functions::HttpResponse HttpConformance(functions::HttpRequest const& request) {
   auto constexpr kOutputFilename = "function_output.json";
   std::ofstream(kOutputFilename) << request.payload() << "\n";
   // This is here just to gracefully shutdown and collect coverage data.
-  if (request.target() == "/quit/program/0") std::exit(0);
+  if (request.target() == "/quit/program/0") shutdown_server = true;
   return functions::HttpResponse{};
 }
 
 int main(int argc, char* argv[]) {
-  return functions::Run(argc, argv, HttpConformance);
+  return google::cloud::functions_internal::RunForTest(
+      argc, argv, HttpConformance,
+      std::function<bool()>{[] { return shutdown_server.load(); }},
+      std::function<void(int)>([](int) {}));
 }

--- a/google/cloud/functions/internal/framework_impl.cc
+++ b/google/cloud/functions/internal/framework_impl.cc
@@ -98,10 +98,15 @@ int RunForTestImpl(int argc, char const* const argv[], UserFunction&& function,
   };
 
   // Reaching this number of sessions triggers a cleanup of any sessions that
-  // may have finished already.
-  auto constexpr kSessionCleanupThreshold = 32;
-  // If we reach this number of sessions we block until we are below the count.
-  auto constexpr kMaximumSessions = 64;
+  // may have finished already. We allow up to 80 sessions to start without
+  // blocking, this should be enough for Cloud Run and Cloud Functions:
+  //     https://cloud.google.com/run/docs/about-concurrency#concurrency_values
+  auto constexpr kSessionCleanupThreshold = 80;
+
+  // If we reach this number of sessions we block until we are below the cleanup
+  // threshold.
+  auto constexpr kMaximumSessions = 160;
+
   std::vector<std::future<void>> sessions;
   while (!shutdown()) {
     if (sessions.size() >= kSessionCleanupThreshold) {


### PR DESCRIPTION
We were creating a thread to handle each request, and then promptly
blocking until the thread completed. With this change we leave the
thread running. Before accepting a new connection we cleanup the memory
resources for old sessions, not that they are that big. We block and
stop accepting requests if there are 64 sessions running, at that point
it is probably better to let the hosting environment (Cloud Run, Cloud
Functions, whatever) create new instances to handle the additional load.

Fixes #309 