### PR TITLE
feat: improve error message for CloudEvent

### DIFF
--- a/google/cloud/functions/internal/parse_cloud_event_json.cc
+++ b/google/cloud/functions/internal/parse_cloud_event_json.cc
@@ -23,6 +23,12 @@ inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
 namespace {
 
 functions::CloudEvent ParseCloudEventJson(nlohmann::json const& json) {
+  if (!json.contains("id") || !json.contains("source") ||
+      !json.contains("type")) {
+    throw std::runtime_error(
+        "JSON message missing `id`, `source`, and/or `type` fields");
+  }
+
   auto event = functions::CloudEvent(
       json.at("id").get<std::string>(), json.at("source").get<std::string>(),
       json.at("type").get<std::string>(),


### PR DESCRIPTION
When parsing CloudEvents in JSON format the error message was a bit
obscure, it indicated that a field was missing, but not which one. This
is more readable in the common case.