### PR TITLE
ci: update to use v1.0.0 of the conformance tests

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -55,19 +55,19 @@ jobs:
         go-version: '1.13'
 
     - name: Run Cloud Event conformance tests
-      uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.2
+      uses: GoogleCloudPlatform/functions-framework-conformance/action@v1.0.0
       with:
         functionType: 'cloudevent'
         useBuildpacks: false
-        validateMapping: false
+        validateMapping: true
         cmd: '${{runner.workspace}}/build/google/cloud/functions/integration_tests/cloud_event_conformance'
 
     - name: Run HTTP conformance tests
-      uses: GoogleCloudPlatform/functions-framework-conformance/action@v0.3.2
+      uses: GoogleCloudPlatform/functions-framework-conformance/action@v1.0.0
       with:
         functionType: 'http'
         useBuildpacks: false
-        validateMapping: false
+        validateMapping: true
         cmd: '${{runner.workspace}}/build/google/cloud/functions/integration_tests/http_conformance'
 
     - name: coverage-upload


### PR DESCRIPTION
Also enable the legacy mapping tests, as the framework now passes them.

Fixes #306 