### PR TITLE
doc: no inline namespaces in Doxygen docs

### DIFF
--- a/google/cloud/functions/cloud_event.cc
+++ b/google/cloud/functions/cloud_event.cc
@@ -16,7 +16,7 @@
 #include <absl/time/time.h>  // NOLINT(modernize-deprecated-headers)
 
 namespace google::cloud::functions {
-inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
 
 void CloudEvent::set_time(std::string const& timestamp) {
   std::string err;
@@ -27,5 +27,5 @@ void CloudEvent::set_time(std::string const& timestamp) {
   set_time(absl::ToChronoTime(time));
 }
 
-}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
 }  // namespace google::cloud::functions

--- a/google/cloud/functions/cloud_event.h
+++ b/google/cloud/functions/cloud_event.h
@@ -21,7 +21,7 @@
 #include <string>
 
 namespace google::cloud::functions {
-inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
 
 /**
  * Represents a Cloud Event.
@@ -95,7 +95,7 @@ class CloudEvent {
   std::optional<std::string> data_;
 };
 
-}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
 }  // namespace google::cloud::functions
 
 #endif  // FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_CLOUD_EVENT_H

--- a/google/cloud/functions/cloud_event_test.cc
+++ b/google/cloud/functions/cloud_event_test.cc
@@ -17,7 +17,7 @@
 #include <gmock/gmock.h>
 
 namespace google::cloud::functions {
-inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
 TEST(CloudEventTest, Basic) {
@@ -116,5 +116,5 @@ TEST(CloudEventTest, DataMove) {
 }
 
 }  // namespace
-}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
 }  // namespace google::cloud::functions

--- a/google/cloud/functions/framework.h
+++ b/google/cloud/functions/framework.h
@@ -20,7 +20,7 @@
 #include <functional>
 
 namespace google::cloud::functions {
-inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
 
 /**
  * Run the given function, invoking it to handle HTTP requests.
@@ -83,7 +83,7 @@ int Run(int argc, char const* const argv[], UserHttpFunction handler) noexcept;
 int Run(int argc, char const* const argv[],
         UserCloudEventFunction handler) noexcept;
 
-}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
 }  // namespace google::cloud::functions
 
 #endif  // FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_FRAMEWORK_H

--- a/google/cloud/functions/http_request.h
+++ b/google/cloud/functions/http_request.h
@@ -21,7 +21,7 @@
 #include <string>
 
 namespace google::cloud::functions {
-inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
 
 /**
  * Represents a HTTP request.
@@ -115,7 +115,7 @@ class HttpRequest {
   int version_minor_ = 1;
 };
 
-}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
 }  // namespace google::cloud::functions
 
 #endif  // FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_HTTP_REQUEST_H

--- a/google/cloud/functions/http_request_test.cc
+++ b/google/cloud/functions/http_request_test.cc
@@ -16,7 +16,7 @@
 #include <gmock/gmock.h>
 
 namespace google::cloud::functions {
-inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
 using ::testing::ElementsAre;
@@ -74,5 +74,5 @@ TEST(HttpRequestTest, ClearHeaders) {
 }
 
 }  // namespace
-}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
 }  // namespace google::cloud::functions

--- a/google/cloud/functions/http_response.cc
+++ b/google/cloud/functions/http_response.cc
@@ -16,11 +16,11 @@
 #include "google/cloud/functions/internal/wrap_response.h"
 
 namespace google::cloud::functions {
-inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
 
 HttpResponse::HttpResponse() : impl_(functions_internal::MakeHttpResponse()) {}
 
 HttpResponse::Impl::~Impl() = default;
 
-}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
 }  // namespace google::cloud::functions

--- a/google/cloud/functions/http_response.h
+++ b/google/cloud/functions/http_response.h
@@ -22,13 +22,13 @@
 #include <string_view>
 
 namespace google::cloud::functions_internal {
-inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
 struct UnwrapResponse;
-}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
 }  // namespace google::cloud::functions_internal
 
 namespace google::cloud::functions {
-inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
 
 /**
  * Represents a HTTP request.
@@ -175,7 +175,7 @@ class HttpResponse {
   std::shared_ptr<Impl> impl_;
 };
 
-}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
 }  // namespace google::cloud::functions
 
 #endif  // FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_HTTP_RESPONSE_H

--- a/google/cloud/functions/http_response_test.cc
+++ b/google/cloud/functions/http_response_test.cc
@@ -16,7 +16,7 @@
 #include <gmock/gmock.h>
 
 namespace google::cloud::functions_internal {
-inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
 using ::testing::ElementsAre;
@@ -68,5 +68,5 @@ TEST(WrapResponseTest, Version) {
 }
 
 }  // namespace
-}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
 }  // namespace google::cloud::functions_internal

--- a/google/cloud/functions/integration_tests/basic_integration_test.cc
+++ b/google/cloud/functions/integration_tests/basic_integration_test.cc
@@ -27,7 +27,7 @@
 #include <thread>
 
 namespace google::cloud::functions_internal {
-inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
 using ::testing::Each;
@@ -238,7 +238,7 @@ TEST(RunIntegrationTest, SomeParallelism) {
 }
 
 }  // namespace
-}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
 }  // namespace google::cloud::functions_internal
 
 int main(int argc, char* argv[]) {

--- a/google/cloud/functions/integration_tests/cloud_event_integration_test.cc
+++ b/google/cloud/functions/integration_tests/cloud_event_integration_test.cc
@@ -29,7 +29,7 @@
 #include <thread>
 
 namespace google::cloud::functions_internal {
-inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
 using ::testing::HasSubstr;
@@ -316,7 +316,7 @@ TEST(RunIntegrationTest, ConformanceSmokeTest) {
 }
 
 }  // namespace
-}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
 }  // namespace google::cloud::functions_internal
 
 int main(int argc, char* argv[]) {

--- a/google/cloud/functions/internal/base64_decode.cc
+++ b/google/cloud/functions/internal/base64_decode.cc
@@ -18,7 +18,7 @@
 #include <stdexcept>
 
 namespace google::cloud::functions_internal {
-inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
 
 std::string Base64Decode(std::string const& base64) {
   if (base64.size() % 4 != 0) {
@@ -50,5 +50,5 @@ std::string Base64Decode(std::string const& base64) {
   return data;
 }
 
-}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
 }  // namespace google::cloud::functions_internal

--- a/google/cloud/functions/internal/base64_decode.h
+++ b/google/cloud/functions/internal/base64_decode.h
@@ -19,11 +19,11 @@
 #include <string>
 
 namespace google::cloud::functions_internal {
-inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
 
 std::string Base64Decode(std::string const& base64);
 
-}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
 }  // namespace google::cloud::functions_internal
 
 #endif  // FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_INTERNAL_BASE64_DECODE_H

--- a/google/cloud/functions/internal/base64_decode_test.cc
+++ b/google/cloud/functions/internal/base64_decode_test.cc
@@ -16,7 +16,7 @@
 #include <gmock/gmock.h>
 
 namespace google::cloud::functions_internal {
-inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
 struct TestData {
@@ -61,5 +61,5 @@ TEST(Base64DecodeTest, Overpadded) {
 }
 
 }  // namespace
-}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
 }  // namespace google::cloud::functions_internal

--- a/google/cloud/functions/internal/build_info.cc.in
+++ b/google/cloud/functions/internal/build_info.cc.in
@@ -17,7 +17,7 @@
 #include <algorithm>
 
 namespace google::cloud::functions_internal {
-inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
 
 std::string Compiler() {
   return CompilerId() + " " + CompilerVersion();
@@ -36,5 +36,5 @@ std::string BuildMetadata() {
   return kBuildMetadata;
 }
 
-}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
 }  // namespace google::cloud::functions_internal

--- a/google/cloud/functions/internal/build_info.h
+++ b/google/cloud/functions/internal/build_info.h
@@ -18,7 +18,7 @@
 #include "google/cloud/functions/version.h"
 
 namespace google::cloud::functions_internal {
-inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
 
 /// The compiler version.
 std::string Compiler();
@@ -29,7 +29,7 @@ std::string CompilerFlags();
 /// Build metadata injected by the build system.
 std::string BuildMetadata();
 
-}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
 }  // namespace google::cloud::functions_internal
 
 #endif  // FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_BUILD_INFO_H

--- a/google/cloud/functions/internal/call_user_function.cc
+++ b/google/cloud/functions/internal/call_user_function.cc
@@ -21,7 +21,7 @@
 #include <stdexcept>
 
 namespace google::cloud::functions_internal {
-inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
 
 namespace be = ::boost::beast;
 
@@ -97,5 +97,5 @@ BeastResponse CallUserFunction(
   return ReportUnknownExceptionInFunction();
 }
 
-}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
 }  // namespace google::cloud::functions_internal

--- a/google/cloud/functions/internal/call_user_function.h
+++ b/google/cloud/functions/internal/call_user_function.h
@@ -19,7 +19,7 @@
 #include "google/cloud/functions/user_functions.h"
 
 namespace google::cloud::functions_internal {
-inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
 
 BeastResponse CallUserFunction(functions::UserHttpFunction const& function,
                                BeastRequest request);
@@ -28,7 +28,7 @@ BeastResponse CallUserFunction(
     functions::UserCloudEventFunction const& function,
     BeastRequest const& request);
 
-}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
 }  // namespace google::cloud::functions_internal
 
 #endif  // FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_INTERNAL_CALL_USER_FUNCTION_H

--- a/google/cloud/functions/internal/call_user_function_test.cc
+++ b/google/cloud/functions/internal/call_user_function_test.cc
@@ -16,7 +16,7 @@
 #include <gmock/gmock.h>
 
 namespace google::cloud::functions_internal {
-inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
 using ::testing::Contains;
@@ -152,5 +152,5 @@ TEST(CallUserFunctionCloudEventTest, InterceptFaviconIco) {
 }
 
 }  // namespace
-}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
 }  // namespace google::cloud::functions_internal

--- a/google/cloud/functions/internal/compiler_info.cc
+++ b/google/cloud/functions/internal/compiler_info.cc
@@ -16,7 +16,7 @@
 #include <sstream>
 
 namespace google::cloud::functions_internal {
-inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
 
 /**
  * The macros for determining the compiler ID are taken from:
@@ -89,5 +89,5 @@ std::string LanguageVersion() {
   }
 }
 
-}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
 }  // namespace google::cloud::functions_internal

--- a/google/cloud/functions/internal/compiler_info.h
+++ b/google/cloud/functions/internal/compiler_info.h
@@ -18,7 +18,7 @@
 #include "google/cloud/functions/version.h"
 
 namespace google::cloud::functions_internal {
-inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
 /**
  * Returns the compiler ID.
  *
@@ -39,7 +39,7 @@ std::string CompilerVersion();
  */
 std::string LanguageVersion();
 
-}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
 }  // namespace google::cloud::functions_internal
 
 #endif  // FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_COMPILER_INFO_H

--- a/google/cloud/functions/internal/compiler_info_test.cc
+++ b/google/cloud/functions/internal/compiler_info_test.cc
@@ -17,7 +17,7 @@
 #include <regex>
 
 namespace google::cloud::functions_internal {
-inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
 using ::testing::Contains;
@@ -48,5 +48,5 @@ TEST(CompilerInfo, LanguageVersion) {
 }
 
 }  // namespace
-}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
 }  // namespace google::cloud::functions_internal

--- a/google/cloud/functions/internal/framework_impl.cc
+++ b/google/cloud/functions/internal/framework_impl.cc
@@ -28,7 +28,7 @@
 #include <thread>
 
 namespace google::cloud::functions_internal {
-inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 namespace be = boost::beast;
 namespace asio = boost::asio;
@@ -153,11 +153,11 @@ int RunForTest(int argc, char const* const argv[],
   return RunForTestImpl(argc, argv, std::move(handler), shutdown, actual_port);
 }
 
-}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
 }  // namespace google::cloud::functions_internal
 
 namespace google::cloud::functions {
-inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
 
 int Run(int argc, char const* const argv[], UserHttpFunction handler) noexcept {
   return functions_internal::RunImpl(argc, argv, std::move(handler));
@@ -168,5 +168,5 @@ int Run(int argc, char const* const argv[],
   return functions_internal::RunImpl(argc, argv, std::move(handler));
 }
 
-}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
 }  // namespace google::cloud::functions

--- a/google/cloud/functions/internal/framework_impl.h
+++ b/google/cloud/functions/internal/framework_impl.h
@@ -20,7 +20,7 @@
 #include <functional>
 
 namespace google::cloud::functions_internal {
-inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Implement functions::Run(), with additional helpers for testing.
 int RunForTest(int argc, char const* const argv[],
@@ -34,7 +34,7 @@ int RunForTest(int argc, char const* const argv[],
                std::function<bool()> const& shutdown,
                std::function<void(int)> const& actual_port);
 
-}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
 }  // namespace google::cloud::functions_internal
 
 #endif  // FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_INTERNAL_FRAMEWORK_IMPL_H

--- a/google/cloud/functions/internal/framework_impl_test.cc
+++ b/google/cloud/functions/internal/framework_impl_test.cc
@@ -22,7 +22,7 @@
 #include <string>
 
 namespace google::cloud::functions_internal {
-inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
 using ::testing::IsEmpty;
@@ -170,5 +170,5 @@ TEST(FrameworkTest, CloudEventInvalidPort) {
 }
 
 }  // namespace
-}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
 }  // namespace google::cloud::functions_internal

--- a/google/cloud/functions/internal/http_message_types.h
+++ b/google/cloud/functions/internal/http_message_types.h
@@ -19,7 +19,7 @@
 #include <boost/beast/http.hpp>
 
 namespace google::cloud::functions_internal {
-inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
 
 using BeastRequest =
     boost::beast::http::request<boost::beast::http::string_body>;
@@ -27,7 +27,7 @@ using BeastRequest =
 using BeastResponse =
     boost::beast::http::response<boost::beast::http::string_body>;
 
-}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
 }  // namespace google::cloud::functions_internal
 
 #endif  // FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_INTERNAL_HTTP_MESSAGE_TYPES_H

--- a/google/cloud/functions/internal/parse_cloud_event_http.cc
+++ b/google/cloud/functions/internal/parse_cloud_event_http.cc
@@ -18,7 +18,7 @@
 #include "google/cloud/functions/internal/parse_cloud_event_storage.h"
 
 namespace google::cloud::functions_internal {
-inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
 
 bool HasHeader(BeastRequest const& request, std::string_view header) {
   return request.count(header) != 0;
@@ -85,5 +85,5 @@ std::vector<functions::CloudEvent> ParseCloudEventHttp(
   return {ParseCloudEventStorage(ParseCloudEventHttpBinary(request))};
 }
 
-}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
 }  // namespace google::cloud::functions_internal

--- a/google/cloud/functions/internal/parse_cloud_event_http.h
+++ b/google/cloud/functions/internal/parse_cloud_event_http.h
@@ -21,7 +21,7 @@
 #include <vector>
 
 namespace google::cloud::functions_internal {
-inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Parse @p request as a Cloud Event, assuming the content type is binary.
 functions::CloudEvent ParseCloudEventHttpBinary(BeastRequest const& request);
@@ -30,7 +30,7 @@ functions::CloudEvent ParseCloudEventHttpBinary(BeastRequest const& request);
 std::vector<functions::CloudEvent> ParseCloudEventHttp(
     BeastRequest const& request);
 
-}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
 }  // namespace google::cloud::functions_internal
 
 #endif  // FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_INTERNAL_PARSE_CLOUD_EVENT_HTTP_H

--- a/google/cloud/functions/internal/parse_cloud_event_http_test.cc
+++ b/google/cloud/functions/internal/parse_cloud_event_http_test.cc
@@ -20,7 +20,7 @@
 #include <iterator>
 
 namespace google::cloud::functions_internal {
-inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
 using ::testing::ElementsAre;
@@ -261,5 +261,5 @@ TEST(ParseCloudEventHttp, BinaryWithUnknownContentType) {
 }
 
 }  // namespace
-}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
 }  // namespace google::cloud::functions_internal

--- a/google/cloud/functions/internal/parse_cloud_event_json.cc
+++ b/google/cloud/functions/internal/parse_cloud_event_json.cc
@@ -19,7 +19,7 @@
 #include <algorithm>
 
 namespace google::cloud::functions_internal {
-inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
 functions::CloudEvent ParseCloudEventJson(nlohmann::json const& json) {
@@ -84,5 +84,5 @@ std::vector<functions::CloudEvent> ParseCloudEventJsonBatch(
   return events;
 }
 
-}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
 }  // namespace google::cloud::functions_internal

--- a/google/cloud/functions/internal/parse_cloud_event_json.h
+++ b/google/cloud/functions/internal/parse_cloud_event_json.h
@@ -21,7 +21,7 @@
 #include <vector>
 
 namespace google::cloud::functions_internal {
-inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Parse @p json_string as a Cloud Event
 functions::CloudEvent ParseCloudEventJson(std::string_view json_string);
@@ -30,7 +30,7 @@ functions::CloudEvent ParseCloudEventJson(std::string_view json_string);
 std::vector<functions::CloudEvent> ParseCloudEventJsonBatch(
     std::string_view json_string);
 
-}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
 }  // namespace google::cloud::functions_internal
 
 #endif  // FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_INTERNAL_PARSE_CLOUD_EVENT_JSON_H

--- a/google/cloud/functions/internal/parse_cloud_event_json_test.cc
+++ b/google/cloud/functions/internal/parse_cloud_event_json_test.cc
@@ -20,7 +20,7 @@
 #include <iterator>
 
 namespace google::cloud::functions_internal {
-inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
 using ::testing::ElementsAre;
@@ -286,5 +286,5 @@ TEST(ParseCloudEventJson, EmulateStorage) {
 }
 
 }  // namespace
-}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
 }  // namespace google::cloud::functions_internal

--- a/google/cloud/functions/internal/parse_cloud_event_legacy.cc
+++ b/google/cloud/functions/internal/parse_cloud_event_legacy.cc
@@ -19,7 +19,7 @@
 #include <utility>
 
 namespace google::cloud::functions_internal {
-inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 std::string GetNestedKey(nlohmann::json const& json,
                          std::deque<std::string> path) {
@@ -289,5 +289,5 @@ functions::CloudEvent ParseCloudEventLegacy(std::string_view json_string) {
   return ParseCloudEventLegacy(json);
 }
 
-}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
 }  // namespace google::cloud::functions_internal

--- a/google/cloud/functions/internal/parse_cloud_event_legacy.h
+++ b/google/cloud/functions/internal/parse_cloud_event_legacy.h
@@ -20,12 +20,12 @@
 #include <string_view>
 
 namespace google::cloud::functions_internal {
-inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Parse @p json_string as one of the legacy GCF event formats.
 functions::CloudEvent ParseCloudEventLegacy(std::string_view json_string);
 
-}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
 }  // namespace google::cloud::functions_internal
 
 #endif  // FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_INTERNAL_PARSE_CLOUD_EVENT_LEGACY_H

--- a/google/cloud/functions/internal/parse_cloud_event_legacy_test.cc
+++ b/google/cloud/functions/internal/parse_cloud_event_legacy_test.cc
@@ -18,7 +18,7 @@
 #include <nlohmann/json.hpp>
 
 namespace google::cloud::functions_internal {
-inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
 // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
@@ -591,5 +591,5 @@ TEST(ParseCloudEventLegacy, MapFirestore) {
 }
 
 }  // namespace
-}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
 }  // namespace google::cloud::functions_internal

--- a/google/cloud/functions/internal/parse_cloud_event_storage.cc
+++ b/google/cloud/functions/internal/parse_cloud_event_storage.cc
@@ -17,7 +17,7 @@
 #include <nlohmann/json.hpp>
 
 namespace google::cloud::functions_internal {
-inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
 
 functions::CloudEvent ParseCloudEventStorage(functions::CloudEvent e) {
   if (e.type() != "google.cloud.pubsub.topic.v1.messagePublished") return e;
@@ -64,5 +64,5 @@ functions::CloudEvent ParseCloudEventStorage(functions::CloudEvent e) {
   return event;
 }
 
-}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
 }  // namespace google::cloud::functions_internal

--- a/google/cloud/functions/internal/parse_cloud_event_storage.h
+++ b/google/cloud/functions/internal/parse_cloud_event_storage.h
@@ -19,12 +19,12 @@
 #include "google/cloud/functions/version.h"
 
 namespace google::cloud::functions_internal {
-inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Parse @p e as a Cloud Storage event if possible, otherwise return @p e.
 functions::CloudEvent ParseCloudEventStorage(functions::CloudEvent e);
 
-}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
 }  // namespace google::cloud::functions_internal
 
 #endif  // FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_INTERNAL_PARSE_CLOUD_EVENT_STORAGE_H

--- a/google/cloud/functions/internal/parse_cloud_event_storage_test.cc
+++ b/google/cloud/functions/internal/parse_cloud_event_storage_test.cc
@@ -20,7 +20,7 @@
 #include <iterator>
 
 namespace google::cloud::functions_internal {
-inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
 TEST(ParseCloudEventJson, EmulateStorageBase) {
@@ -332,5 +332,5 @@ TEST(ParseCloudEventJson, EmulateStorageMissingInvalidAttributeField) {
 }
 
 }  // namespace
-}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
 }  // namespace google::cloud::functions_internal

--- a/google/cloud/functions/internal/parse_options.cc
+++ b/google/cloud/functions/internal/parse_options.cc
@@ -19,7 +19,7 @@
 #include <stdexcept>
 
 namespace google::cloud::functions_internal {
-inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
 namespace po = boost::program_options;
 
 auto constexpr kDefaultPort = 8080;
@@ -73,5 +73,5 @@ po::variables_map ParseOptions(int argc, char const* const argv[]) {
   throw std::invalid_argument(std::move(os).str());
 }
 
-}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
 }  // namespace google::cloud::functions_internal

--- a/google/cloud/functions/internal/parse_options.h
+++ b/google/cloud/functions/internal/parse_options.h
@@ -19,13 +19,13 @@
 #include <boost/program_options/variables_map.hpp>
 
 namespace google::cloud::functions_internal {
-inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Parse the command-line options in @p argv
 boost::program_options::variables_map ParseOptions(int argc,
                                                    char const* const argv[]);
 
-}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
 }  // namespace google::cloud::functions_internal
 
 #endif  // FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_INTERNAL_PARSE_OPTIONS_H

--- a/google/cloud/functions/internal/parse_options_test.cc
+++ b/google/cloud/functions/internal/parse_options_test.cc
@@ -17,7 +17,7 @@
 #include <gmock/gmock.h>
 
 namespace google::cloud::functions_internal {
-inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
 TEST(WrapRequestTest, NoCmd) {
@@ -111,5 +111,5 @@ TEST(WrapRequestTest, PortCommandLineInvalid) {
 }
 
 }  // namespace
-}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
 }  // namespace google::cloud::functions_internal

--- a/google/cloud/functions/internal/setenv.cc
+++ b/google/cloud/functions/internal/setenv.cc
@@ -19,7 +19,7 @@
 #include <stdlib.h>  // NOLINT(modernize-deprecated-headers)
 
 namespace google::cloud::functions_internal {
-inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
 
 namespace {
 void UnsetEnv(char const* variable) {
@@ -49,5 +49,5 @@ void SetEnv(std::string const& variable,
   SetEnv(variable.c_str(), value->c_str());
 }
 
-}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
 }  // namespace google::cloud::functions_internal

--- a/google/cloud/functions/internal/setenv.h
+++ b/google/cloud/functions/internal/setenv.h
@@ -20,13 +20,13 @@
 #include <string>
 
 namespace google::cloud::functions_internal {
-inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Changes an environment variable in the current process.
 void SetEnv(std::string const& variable,
             std::optional<std::string> const& value);
 
-}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
 }  // namespace google::cloud::functions_internal
 
 #endif  // FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_SETENV_H

--- a/google/cloud/functions/internal/wrap_request.cc
+++ b/google/cloud/functions/internal/wrap_request.cc
@@ -16,7 +16,7 @@
 #include "google/cloud/functions/http_request.h"
 
 namespace google::cloud::functions_internal {
-inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
 
 ::google::cloud::functions::HttpRequest MakeHttpRequest(BeastRequest request) {
   auto constexpr kBeastHttpVersionFactor = 10;
@@ -33,5 +33,5 @@ inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
   return r;
 }
 
-}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
 }  // namespace google::cloud::functions_internal

--- a/google/cloud/functions/internal/wrap_request.h
+++ b/google/cloud/functions/internal/wrap_request.h
@@ -20,12 +20,12 @@
 #include "google/cloud/functions/version.h"
 
 namespace google::cloud::functions_internal {
-inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Wrap a Boost.Beast request into a functions framework HTTP request.
 ::google::cloud::functions::HttpRequest MakeHttpRequest(BeastRequest request);
 
-}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
 }  // namespace google::cloud::functions_internal
 
 #endif  // FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_INTERNAL_WRAP_REQUEST_H

--- a/google/cloud/functions/internal/wrap_request_test.cc
+++ b/google/cloud/functions/internal/wrap_request_test.cc
@@ -16,7 +16,7 @@
 #include <gmock/gmock.h>
 
 namespace google::cloud::functions_internal {
-inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
 using ::testing::ElementsAre;
@@ -41,5 +41,5 @@ TEST(WrapRequestTest, Basic) {
 }
 
 }  // namespace
-}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
 }  // namespace google::cloud::functions_internal

--- a/google/cloud/functions/internal/wrap_response.cc
+++ b/google/cloud/functions/internal/wrap_response.cc
@@ -15,12 +15,12 @@
 #include "google/cloud/functions/internal/wrap_response.h"
 
 namespace google::cloud::functions_internal {
-inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Wrap a Boost.Beast request into a functions framework HTTP request.
 std::shared_ptr<functions::HttpResponse::Impl> MakeHttpResponse() {
   return std::make_shared<WrapResponseImpl>();
 }
 
-}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
 }  // namespace google::cloud::functions_internal

--- a/google/cloud/functions/internal/wrap_response.h
+++ b/google/cloud/functions/internal/wrap_response.h
@@ -20,7 +20,7 @@
 #include "google/cloud/functions/version.h"
 
 namespace google::cloud::functions_internal {
-inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
 
 struct UnwrapResponse;
 
@@ -70,7 +70,7 @@ class WrapResponseImpl : public google::cloud::functions::HttpResponse::Impl {
 /// Wrap a Boost.Beast request into a functions framework HTTP request.
 std::shared_ptr<functions::HttpResponse::Impl> MakeHttpResponse();
 
-}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
 }  // namespace google::cloud::functions_internal
 
 #endif  // FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_INTERNAL_WRAP_RESPONSE_H

--- a/google/cloud/functions/user_functions.h
+++ b/google/cloud/functions/user_functions.h
@@ -22,14 +22,14 @@
 #include <functional>
 
 namespace google::cloud::functions {
-inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
 
 using UserHttpFunction =
     std::function<functions::HttpResponse(functions::HttpRequest)>;
 
 using UserCloudEventFunction = std::function<void(functions::CloudEvent)>;
 
-}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
 }  // namespace google::cloud::functions
 
 #endif  // FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_USER_FUNCTIONS_H

--- a/google/cloud/functions/version.cc
+++ b/google/cloud/functions/version.cc
@@ -17,7 +17,7 @@
 #include <sstream>
 
 namespace google::cloud::functions {
-inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
 
 std::string VersionString() {
   static std::string const kVersion = [] {
@@ -33,5 +33,5 @@ std::string VersionString() {
   return kVersion;
 }
 
-}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
 }  // namespace google::cloud::functions

--- a/google/cloud/functions/version.h
+++ b/google/cloud/functions/version.h
@@ -24,12 +24,13 @@
 #define FUNCTIONS_FRAMEWORK_CPP_NS                                     \
   FUNCTIONS_FRAMEWORK_CPP_VEVAL(FUNCTIONS_FRAMEWORK_CPP_VERSION_MAJOR, \
                                 FUNCTIONS_FRAMEWORK_CPP_VERSION_MINOR)
+#define FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN \
+  inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+#define FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END \
+  } /* namespace FUNCTIONS_FRAMEWORK_CPP_NS */
 
 namespace google::cloud::functions {
-/**
- * The C++ Functions Framework inlined, versioned namespace.
- */
-inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
 /// The C++ Functions Framework major version.
 int constexpr VersionMajor() { return FUNCTIONS_FRAMEWORK_CPP_VERSION_MAJOR; }
 
@@ -58,7 +59,7 @@ int constexpr Version() {
 /// The version as a string, in MAJOR.MINOR.PATCH+gitrev format.
 std::string VersionString();
 
-}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
 }  // namespace google::cloud::functions
 
 #endif  // FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_VERSION_H

--- a/google/cloud/functions/version_test.cc
+++ b/google/cloud/functions/version_test.cc
@@ -18,7 +18,7 @@
 #include <sstream>
 
 namespace google::cloud::functions {
-inline namespace FUNCTIONS_FRAMEWORK_CPP_NS {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
 using ::testing::HasSubstr;
@@ -54,5 +54,5 @@ TEST(VersionTest, NoBuildInfoInRelease) {
 }
 
 }  // namespace
-}  // namespace FUNCTIONS_FRAMEWORK_CPP_NS
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
 }  // namespace google::cloud::functions


### PR DESCRIPTION
Well, we do not have Doxygen docs right now, but if we did, we do not
want the inline namespace to appear in the docs.