### PR TITLE
impl: a generic wrapper for functions

### DIFF
--- a/google/cloud/functions/CMakeLists.txt
+++ b/google/cloud/functions/CMakeLists.txt
@@ -30,6 +30,8 @@ add_library(
     cloud_event.cc
     cloud_event.h
     framework.h
+    function.cc
+    function.h
     http_request.h
     http_response.cc
     http_response.h
@@ -42,6 +44,8 @@ add_library(
     internal/compiler_info.h
     internal/framework_impl.cc
     internal/framework_impl.h
+    internal/function_impl.cc
+    internal/function_impl.h
     internal/http_message_types.h
     internal/parse_cloud_event_http.cc
     internal/parse_cloud_event_http.h
@@ -97,6 +101,7 @@ if (BUILD_TESTING)
         internal/call_user_function_test.cc
         internal/compiler_info_test.cc
         internal/framework_impl_test.cc
+        internal/function_impl_test.cc
         internal/parse_cloud_event_http_test.cc
         internal/parse_cloud_event_json_test.cc
         internal/parse_cloud_event_legacy_test.cc

--- a/google/cloud/functions/function.cc
+++ b/google/cloud/functions/function.cc
@@ -1,0 +1,45 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/functions/function.h"
+#include "google/cloud/functions/internal/function_impl.h"
+
+namespace google::cloud::functions {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
+
+Function::~Function() = default;
+
+Function::Function(std::shared_ptr<functions_internal::FunctionImpl> impl)
+    : impl_(std::move(impl)) {}
+
+Function MakeFunction(UserHttpFunction function) {
+  return functions_internal::FunctionImpl::MakeFunction(
+      std::make_shared<functions_internal::BaseFunctionImpl>(
+          std::move(function)));
+}
+
+Function MakeFunction(UserCloudEventFunction function) {
+  return functions_internal::FunctionImpl::MakeFunction(
+      std::make_shared<functions_internal::BaseFunctionImpl>(
+          std::move(function)));
+}
+
+Function MakeFunction(std::map<std::string, Function> mapping) {
+  return functions_internal::FunctionImpl::MakeFunction(
+      std::make_shared<functions_internal::MapFunctionImpl>(
+          std::move(mapping)));
+}
+
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
+}  // namespace google::cloud::functions

--- a/google/cloud/functions/function.h
+++ b/google/cloud/functions/function.h
@@ -1,0 +1,98 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_FUNCTION_H
+#define FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_FUNCTION_H
+
+#include "google/cloud/functions/user_functions.h"
+#include "google/cloud/functions/version.h"
+#include <map>
+
+namespace google::cloud::functions_internal {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
+class FunctionImpl;
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
+}  // namespace google::cloud::functions_internal
+
+namespace google::cloud::functions {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
+
+/**
+ * An opaque wrapper around user-defined `http` and `cloud event` functions.
+ *
+ * This class can hold any of the function types supported by the C++ functions
+ * framework.  The framework provides a number of factory functions to create
+ * `Function` objects from application defined functions.
+ *
+ * When using the functions framework for local development applications can
+ * create a HTTP server using:
+ *
+ * @code
+ * namespace gcf = google::cloud::functions;
+ * auto MyFunction() { return gcf::MakeFunction(callable); }
+ * int main(int argc, char* argv[]) {
+ *   return gcf::Run(argc, argv, MyFunction());
+ * }
+ * @endcode
+ *
+ * When using one of the buildpacks, the application defines the factory
+ * function and references it (by name) in the GOOGLE_FUNCTION_TARGET setting:
+ *
+ * @code
+ * namespace my_namespace {
+ * gcf::HttpResponse Handler(gcf::Request const&) { ... code here ... }
+ *
+ * // Use by setting GOOGLE_FUNCTION_TARGET to "my_namespace::MyFunction"
+ * auto MyFunction() { return gcf::MakeFunction(Handler); }
+ * } //
+ * @endcode
+ */
+class Function {
+ public:
+  ~Function();
+
+  friend bool operator==(Function const& lhs, Function const& rhs) {
+    return lhs.impl_ == rhs.impl_;
+  }
+  friend bool operator!=(Function const& lhs, Function const& rhs) {
+    return !(lhs == rhs);
+  }
+
+ private:
+  friend class functions_internal::FunctionImpl;
+
+  explicit Function(std::shared_ptr<functions_internal::FunctionImpl>);
+  std::shared_ptr<functions_internal::FunctionImpl> impl_;
+};
+
+/// Wraps a `http` handler.
+Function MakeFunction(UserHttpFunction function);
+
+/// Wraps a `cloud event` handler.
+Function MakeFunction(UserCloudEventFunction function);
+
+/**
+ * Creates a function with support for runtime-assigned targets.
+ *
+ * Given a map from function names to `Function` objects it creates a new
+ * function that will, at runtime, retrieve the correct function from the map,
+ * and install it as the handler. This assignment happens during function
+ * startup.
+ */
+Function MakeFunction(std::map<std::string, Function> mapping);
+
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
+}  // namespace google::cloud::functions
+
+#endif  // FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_FUNCTION_H

--- a/google/cloud/functions/internal/function_impl.cc
+++ b/google/cloud/functions/internal/function_impl.cc
@@ -1,0 +1,56 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/functions/internal/function_impl.h"
+#include "google/cloud/functions/internal/call_user_function.h"
+#include "google/cloud/functions/function.h"
+
+namespace google::cloud::functions_internal {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
+
+std::shared_ptr<FunctionImpl> FunctionImpl::GetImpl(
+    functions::Function const& fun) {
+  return fun.impl_;
+}
+
+functions::Function FunctionImpl::MakeFunction(
+    std::shared_ptr<FunctionImpl> impl) {
+  return functions::Function(std::move(impl));
+}
+
+BaseFunctionImpl::BaseFunctionImpl(functions::UserHttpFunction function)
+    : handler_([fun = std::move(function)](BeastRequest request) {
+        return CallUserFunction(fun, std::move(request));
+      }) {}
+
+BaseFunctionImpl::BaseFunctionImpl(functions::UserCloudEventFunction function)
+    : handler_([fun = std::move(function)](BeastRequest const& request) {
+        return CallUserFunction(fun, request);
+      }) {}
+
+MapFunctionImpl::MapFunctionImpl(
+    std::map<std::string, functions::Function> mapping)
+    : mapping_(std::move(mapping)) {}
+
+[[nodiscard]] Handler MapFunctionImpl::GetHandler(
+    std::string_view target) const {
+  auto const l = mapping_.find(std::string(target));
+  if (l == mapping_.end()) {
+    throw std::runtime_error("Function not found " + std::string(target));
+  }
+  return FunctionImpl::GetImpl(l->second)->GetHandler(target);
+}
+
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
+}  // namespace google::cloud::functions_internal

--- a/google/cloud/functions/internal/function_impl.h
+++ b/google/cloud/functions/internal/function_impl.h
@@ -1,0 +1,72 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_INTERNAL_FUNCTION_IMPL_H
+#define FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_INTERNAL_FUNCTION_IMPL_H
+
+#include "google/cloud/functions/internal/http_message_types.h"
+#include "google/cloud/functions/user_functions.h"
+#include "google/cloud/functions/version.h"
+#include <map>
+#include <string_view>
+
+namespace google::cloud::functions {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
+class Function;
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
+}  // namespace google::cloud::functions
+
+namespace google::cloud::functions_internal {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
+
+using Handler = std::function<BeastResponse(BeastRequest)>;
+
+class FunctionImpl {
+ public:
+  virtual ~FunctionImpl() = default;
+  [[nodiscard]] virtual Handler GetHandler(std::string_view target) const = 0;
+
+  static std::shared_ptr<FunctionImpl> GetImpl(functions::Function const& fun);
+  static functions::Function MakeFunction(std::shared_ptr<FunctionImpl> impl);
+};
+
+class BaseFunctionImpl : public FunctionImpl {
+ public:
+  explicit BaseFunctionImpl(functions::UserHttpFunction handler);
+  explicit BaseFunctionImpl(functions::UserCloudEventFunction handler);
+  ~BaseFunctionImpl() override = default;
+
+  [[nodiscard]] Handler GetHandler(std::string_view /*target*/) const override {
+    return handler_;
+  }
+
+ private:
+  Handler handler_;
+};
+
+class MapFunctionImpl : public FunctionImpl {
+ public:
+  explicit MapFunctionImpl(std::map<std::string, functions::Function> mapping);
+  ~MapFunctionImpl() override = default;
+
+  [[nodiscard]] Handler GetHandler(std::string_view target) const override;
+
+ private:
+  std::map<std::string, functions::Function> mapping_;
+};
+
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
+}  // namespace google::cloud::functions_internal
+
+#endif  // FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_INTERNAL_FUNCTION_IMPL_H

--- a/google/cloud/functions/internal/function_impl_test.cc
+++ b/google/cloud/functions/internal/function_impl_test.cc
@@ -1,0 +1,140 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/functions/internal/function_impl.h"
+#include "google/cloud/functions/function.h"
+#include <gmock/gmock.h>
+
+namespace google::cloud::functions_internal {
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
+namespace {
+
+using ::testing::HasSubstr;
+namespace http = ::boost::beast::http;
+
+auto SimpleHttp(functions::HttpRequest const& request) {
+  std::string payload = request.payload();
+  payload += "\n";
+  payload += ":target: ";
+  payload += request.target();
+  for (auto const& [k, v] : request.headers()) {
+    payload += "\n";
+    payload += k;
+    payload += ": ";
+    payload += v;
+  }
+  return functions::HttpResponse{}.set_payload(std::move(payload));
+}
+
+functions::HttpResponse AlwaysThrowHttp(
+    functions::HttpRequest const& /*request*/) {
+  throw std::runtime_error("testing");
+}
+
+auto TestCloudEventRequest() {
+  auto constexpr kText = R"js({
+    "type" : "com.example.someevent",
+    "source" : "/mycontext",
+    "id" : "A234-1234-1234"})js";
+  BeastRequest request;
+  request.target("/hello");
+  request.insert("content-type", "application/cloudevents+json; charset=utf-8");
+  request.body() = kText;
+  request.prepare_payload();
+  return request;
+}
+
+TEST(FunctionImpl, HttpNormal) {
+  auto function = functions::MakeFunction(SimpleHttp);
+  auto handler = FunctionImpl::GetImpl(function)->GetHandler("unused");
+  BeastRequest request;
+  request.target("/test-target");
+  request.insert("x-test-header", "value");
+  auto response = handler(request);
+  EXPECT_EQ(response.result(), http::status::ok);
+  EXPECT_THAT(response.body(), HasSubstr(":target: /test-target"));
+  EXPECT_THAT(response.body(), HasSubstr("x-test-header: value"));
+}
+
+TEST(FunctionImpl, HttpThrow) {
+  auto function = functions::MakeFunction(AlwaysThrowHttp);
+  auto handler = FunctionImpl::GetImpl(function)->GetHandler("unused");
+  BeastRequest request;
+  request.target("/test-target");
+  auto response = handler(request);
+  EXPECT_EQ(response.result(), http::status::internal_server_error);
+}
+
+TEST(FunctionImpl, CloudEventNormal) {
+  auto func = [](functions::CloudEvent const& event) {
+    EXPECT_EQ(event.id(), "A234-1234-1234");
+    EXPECT_EQ(event.source(), "/mycontext");
+    EXPECT_EQ(event.type(), "com.example.someevent");
+  };
+  auto function = functions::MakeFunction(func);
+  auto handler = FunctionImpl::GetImpl(function)->GetHandler("unused");
+  auto response = handler(TestCloudEventRequest());
+  EXPECT_EQ(response.result(), http::status::ok);
+}
+
+TEST(FunctionImpl, CloudEventThrow) {
+  auto func = [](functions::CloudEvent const& /*event*/) {
+    throw std::runtime_error("testing");
+  };
+  auto function = functions::MakeFunction(func);
+  auto handler = FunctionImpl::GetImpl(function)->GetHandler("unused");
+  auto response = handler(TestCloudEventRequest());
+  EXPECT_EQ(response.result(), http::status::internal_server_error);
+}
+
+auto MakeTestMapFunction() {
+  auto a = [](functions::HttpRequest const& /*r*/) {
+    return functions::HttpResponse{}.set_payload("a");
+  };
+  auto b = [](functions::HttpRequest const& /*r*/) {
+    return functions::HttpResponse{}.set_payload("c");
+  };
+  auto c = [](functions::CloudEvent const& /*e*/) {
+    throw std::runtime_error("testing");
+  };
+  return functions::MakeFunction({
+      {"a", functions::MakeFunction(a)},
+      {"b", functions::MakeFunction(b)},
+      {"c", functions::MakeFunction(c)},
+  });
+}
+
+TEST(FunctionImpl, MapNormal) {
+  auto function = MakeTestMapFunction();
+  auto handler = FunctionImpl::GetImpl(function)->GetHandler("a");
+  auto response = handler(BeastRequest());
+  EXPECT_EQ(response.body(), "a");
+}
+
+TEST(FunctionImpl, MapThrow) {
+  auto function = MakeTestMapFunction();
+  auto handler = FunctionImpl::GetImpl(function)->GetHandler("c");
+  auto response = handler(TestCloudEventRequest());
+  EXPECT_EQ(response.result(), http::status::internal_server_error);
+}
+
+TEST(FunctionImpl, MapInvalid) {
+  auto function = MakeTestMapFunction();
+  EXPECT_THROW((void)FunctionImpl::GetImpl(function)->GetHandler("invalid"),
+               std::exception);
+}
+
+}  // namespace
+FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_END
+}  // namespace google::cloud::functions_internal


### PR DESCRIPTION
This introduces `functions::Function`, a generic wrapper for all valid
function signatures. The wrapper is not (yet) usable, I am missing the
changes to `functions::Run()`. The PR is a good stopping point.