### PR TITLE
feat: support `functions::Function` in `Run()`

### DIFF
--- a/google/cloud/functions/framework.h
+++ b/google/cloud/functions/framework.h
@@ -15,6 +15,7 @@
 #ifndef FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_FRAMEWORK_H
 #define FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_FRAMEWORK_H
 
+#include "google/cloud/functions/function.h"
 #include "google/cloud/functions/user_functions.h"
 #include "google/cloud/functions/version.h"
 #include <functional>
@@ -23,12 +24,50 @@ namespace google::cloud::functions {
 FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
 
 /**
- * Run the given function, invoking it to handle HTTP requests.
+ * Runs function wrapped by @p handler.
  *
  * Starts a HTTP server at the address and listening endpoint described by
  * @p argv, invoking @p handler to handle any HTTP request.
  *
- * When deploying code to Google Cloud Functions applications should**not** use
+ * If @p handler wraps a function with the Cloud Event signature, then the
+ * incoming HTTP requests **MUST** conform to the Cloud Events [HTTP protocol
+ * binding specification][cloud-events-spec].
+ *
+ * @note
+ * When deploying code to Google Cloud Functions applications should **not** use
+ * this function directly. The buildpack will automatically create a `main()`
+ * and invoke `Run()` with the correct parameters. We recommend that application
+ * developers use this function only for local development and integration
+ * tests.
+ *
+ * @par Example
+ * @code
+ * namespace gcf = ::google::cloud::functions;
+ *
+ * extern gcf::HttpResponse MyHandler(gcf::HttpRequest);
+ *
+ * int main(int argc, char* argv[]) {
+ *   return gcf::Run(argc, argv, gcf::MakeFunction(MyHandler));
+ * }
+ * @endcode
+ *
+ * @see ParseOptions for more details of the command-line arguments used by this
+ *     function.
+ *
+ * [cloud-events-spec]:
+ * https://github.com/cloudevents/spec/blob/v1.0/http-protocol-binding.md
+ */
+int Run(int argc, char const* const argv[], Function const& handler) noexcept;
+
+/**
+ * Run the given function, invoking it to handle HTTP requests.
+ *
+ * @deprecated Prefer using the overload consuming a `Function` object.
+ *
+ * Starts a HTTP server at the address and listening endpoint described by
+ * @p argv, invoking @p handler to handle any HTTP request.
+ *
+ * When deploying code to Google Cloud Functions applications should **not** use
  * this function directly. The buildpack will automatically create a `main()`
  * and invoke `Run()` with the correct parameters. We recommend that application
  * developers use this function only for local development and integration
@@ -53,11 +92,13 @@ int Run(int argc, char const* const argv[], UserHttpFunction handler) noexcept;
 /**
  * Run the given function, invoking it to handle Cloud Events.
  *
+ * @deprecated Prefer using the overload consuming a `Function` object.
+ *
  * Starts a HTTP server at the address and listening endpoint described by
  * @p argv, invoking @p handler to handle any HTTP request which *MUST* conform
  * to the Cloud Events [HTTP protocol binding][cloud-events-spec].
  *
- * When deploying code to Google Cloud Functions applications should**not** use
+ * When deploying code to Google Cloud Functions applications should **not** use
  * this function directly. The buildpack will automatically create a `main()`
  * and invoke `Run()` with the correct parameters. We recommend that application
  * developers use this function only for local development and integration

--- a/google/cloud/functions/integration_tests/cloud_event_conformance.cc
+++ b/google/cloud/functions/integration_tests/cloud_event_conformance.cc
@@ -63,6 +63,6 @@ void CloudEventConformance(functions::CloudEvent const& ev) {
 
 int main(int argc, char* argv[]) {
   return google::cloud::functions_internal::RunForTest(
-      argc, argv, CloudEventConformance, [] { return shutdown_server.load(); },
-      [](int /*port*/) {});
+      argc, argv, functions::MakeFunction(CloudEventConformance),
+      [] { return shutdown_server.load(); }, [](int /*port*/) {});
 }

--- a/google/cloud/functions/integration_tests/cloud_event_handler.cc
+++ b/google/cloud/functions/integration_tests/cloud_event_handler.cc
@@ -38,6 +38,6 @@ void CloudEventHandler(CloudEvent const& event) {
 
 int main(int argc, char* argv[]) {
   return google::cloud::functions_internal::RunForTest(
-      argc, argv, CloudEventHandler, [] { return shutdown_server.load(); },
-      [](int /*port*/) {});
+      argc, argv, google::cloud::functions::MakeFunction(CloudEventHandler),
+      [] { return shutdown_server.load(); }, [](int /*port*/) {});
 }

--- a/google/cloud/functions/integration_tests/echo_server.cc
+++ b/google/cloud/functions/integration_tests/echo_server.cc
@@ -71,6 +71,6 @@ HttpResponse EchoServer(HttpRequest const& request) {
 
 int main(int argc, char* argv[]) {
   return google::cloud::functions_internal::RunForTest(
-      argc, argv, EchoServer, [] { return shutdown_server.load(); },
-      [](int /*port*/) {});
+      argc, argv, google::cloud::functions::MakeFunction(EchoServer),
+      [] { return shutdown_server.load(); }, [](int /*port*/) {});
 }

--- a/google/cloud/functions/integration_tests/http_conformance.cc
+++ b/google/cloud/functions/integration_tests/http_conformance.cc
@@ -30,6 +30,6 @@ functions::HttpResponse HttpConformance(functions::HttpRequest const& request) {
 
 int main(int argc, char* argv[]) {
   return google::cloud::functions_internal::RunForTest(
-      argc, argv, HttpConformance, [] { return shutdown_server.load(); },
-      [](int /*port*/) {});
+      argc, argv, google::cloud::functions::MakeFunction(HttpConformance),
+      [] { return shutdown_server.load(); }, [](int /*port*/) {});
 }

--- a/google/cloud/functions/internal/framework_impl.h
+++ b/google/cloud/functions/internal/framework_impl.h
@@ -15,6 +15,7 @@
 #ifndef FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_INTERNAL_FRAMEWORK_IMPL_H
 #define FUNCTIONS_FRAMEWORK_CPP_GOOGLE_CLOUD_FUNCTIONS_INTERNAL_FRAMEWORK_IMPL_H
 
+#include "google/cloud/functions/function.h"
 #include "google/cloud/functions/user_functions.h"
 #include "google/cloud/functions/version.h"
 #include <functional>
@@ -24,13 +25,7 @@ FUNCTIONS_FRAMEWORK_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Implement functions::Run(), with additional helpers for testing.
 int RunForTest(int argc, char const* const argv[],
-               functions::UserHttpFunction handler,
-               std::function<bool()> const& shutdown,
-               std::function<void(int)> const& actual_port);
-
-/// Implement functions::Run(), with additional helpers for testing.
-int RunForTest(int argc, char const* const argv[],
-               functions::UserCloudEventFunction handler,
+               functions::Function const& handler,
                std::function<bool()> const& shutdown,
                std::function<void(int)> const& actual_port);
 

--- a/google/cloud/functions/internal/framework_impl_test.cc
+++ b/google/cloud/functions/internal/framework_impl_test.cc
@@ -110,7 +110,8 @@ TEST(FrameworkTest, Http) {
   auto run = [&](int argc, char const* const argv[],
                  functions::UserHttpFunction f) {
     return RunForTest(
-        argc, argv, std::move(f), [&shutdown]() { return shutdown.load(); },
+        argc, argv, functions::MakeFunction(std::move(f)),
+        [&shutdown]() { return shutdown.load(); },
         [&port_p](int port) mutable { port_p.set_value(port); });
   };
   auto done = std::async(std::launch::async, run, static_cast<int>(kTestArgc),
@@ -143,7 +144,8 @@ TEST(FrameworkTest, CloudEvent) {
   auto run = [&](int argc, char const* const argv[],
                  functions::UserCloudEventFunction f) {
     return RunForTest(
-        argc, argv, std::move(f), [&shutdown]() { return shutdown.load(); },
+        argc, argv, functions::MakeFunction(std::move(f)),
+        [&shutdown]() { return shutdown.load(); },
         [&port_p](int port) mutable { port_p.set_value(port); });
   };
   auto done = std::async(std::launch::async, run, static_cast<int>(kTestArgc),


### PR DESCRIPTION
Application developers can use `functions::Function` as a wrapper for
their functions in unit and integration tests.  Note that we need to
change the buildpacks (in a separate repository) to completely support
this feature.