### PR TITLE
refactor: use `GOOGLE_` prefix in buildpack

### DIFF
--- a/build_scripts/pack/build.in
+++ b/build_scripts/pack/build.in
@@ -214,7 +214,7 @@ generate_main() {
 }
 
 generate_main \
-    "${TARGET_FUNCTION}" "${FUNCTION_SIGNATURE_TYPE:-http}" >"${layers}/source/main.cc"
+    "${GOOGLE_FUNCTION_TARGET}" "${GOOGLE_FUNCTION_SIGNATURE_TYPE:-http}" >"${layers}/source/main.cc"
 
 echo "-----> Configure Function"
 cat >"${layers}/binary.toml" <<_EOF_

--- a/build_scripts/pack/cloudbuild.yaml
+++ b/build_scripts/pack/cloudbuild.yaml
@@ -67,8 +67,8 @@ steps:
   - name: 'pack'
     args: ['build', 'test-builder',
            '--builder', 'gcr.io/${PROJECT_ID}/functions-framework-cpp/builder:bionic',
-           '--env', 'FUNCTION_SIGNATURE_TYPE=http',
-           '--env', 'TARGET_FUNCTION=HelloWorld',
+           '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=http',
+           '--env', 'GOOGLE_FUNCTION_TARGET=HelloWorld',
            '--path', 'examples/hello_world',
     ]
 

--- a/ci/README.md
+++ b/ci/README.md
@@ -122,17 +122,17 @@ Create containers for the Hello World examples:
 
 ```sh
 pack build -v \
-    --env FUNCTION_SIGNATURE_TYPE=cloudevent \
-    --env TARGET_FUNCTION=hello_world_pubsub \
+    --env GOOGLE_FUNCTION_SIGNATURE_TYPE=cloudevent \
+    --env GOOGLE_FUNCTION_TARGET=hello_world_pubsub \
     --path examples/site/hello_world_pubsub \
     "gcr.io/${GOOGLE_CLOUD_PROJECT}/gcf-hello-world-pubsub"
 pack build -v \
-    --env FUNCTION_SIGNATURE_TYPE=cloudevent \
-    --env TARGET_FUNCTION=hello_world_storage \
+    --env GOOGLE_FUNCTION_SIGNATURE_TYPE=cloudevent \
+    --env GOOGLE_FUNCTION_TARGET=hello_world_storage \
     --path examples/site/hello_world_storage \
     "gcr.io/${GOOGLE_CLOUD_PROJECT}/gcf-hello-world-storage"
 pack build -v \
-    --env TARGET_FUNCTION=hello_world_http \
+    --env GOOGLE_FUNCTION_TARGET=hello_world_http \
     --path examples/site/hello_world_http \
     "gcr.io/${GOOGLE_CLOUD_PROJECT}/gcf-hello-world-http"
 ```
@@ -301,7 +301,7 @@ Build & deploy the Bigtable tutorial function:
 
 ```shell
 pack build -v \
-    --env TARGET_FUNCTION=tutorial_cloud_bigtable \
+    --env GOOGLE_FUNCTION_TARGET=tutorial_cloud_bigtable \
     --path examples/site/tutorial_cloud_bigtable \
     "gcr.io/${GOOGLE_CLOUD_PROJECT}/gcf-tutorial-cloud-bigtable"
 docker push "gcr.io/${GOOGLE_CLOUD_PROJECT}/gcf-tutorial-cloud-bigtable"
@@ -345,7 +345,7 @@ To populate the database, use the spanner examples from the C++ client library:
 
 ```shell
 pack build -v \
-    --env TARGET_FUNCTION=tutorial_cloud_spanner \
+    --env GOOGLE_FUNCTION_TARGET=tutorial_cloud_spanner \
     --path examples/site/tutorial_cloud_spanner \
     "gcr.io/${GOOGLE_CLOUD_PROJECT}/gcf-tutorial-cloud-spanner"
 docker push "gcr.io/${GOOGLE_CLOUD_PROJECT}/gcf-tutorial-cloud-spanner"

--- a/ci/build-examples.yaml
+++ b/ci/build-examples.yaml
@@ -62,8 +62,8 @@ steps:
     waitFor: ['gcf-builder-ready']
     id: 'hello-cloud-event'
     args: ['build',
-      '--env', 'FUNCTION_SIGNATURE_TYPE=cloudevent',
-      '--env', 'TARGET_FUNCTION=HelloCloudEvent',
+      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=cloudevent',
+      '--env', 'GOOGLE_FUNCTION_TARGET=HelloCloudEvent',
       '--path', 'examples/hello_cloud_event',
       'hello-cloud-event',
     ]
@@ -72,8 +72,8 @@ steps:
     waitFor: ['gcf-builder-ready']
     id: 'hello-from-namespace'
     args: ['build',
-      '--env', 'FUNCTION_SIGNATURE_TYPE=http',
-      '--env', 'TARGET_FUNCTION=hello_from_namespace::HelloWorld',
+      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=http',
+      '--env', 'GOOGLE_FUNCTION_TARGET=hello_from_namespace::HelloWorld',
       '--path', 'examples/hello_from_namespace',
       'hello-from-namespace',
     ]
@@ -82,8 +82,8 @@ steps:
     waitFor: ['gcf-builder-ready']
     id: 'hello-from-namespace-rooted'
     args: ['build',
-      '--env', 'FUNCTION_SIGNATURE_TYPE=http',
-      '--env', 'TARGET_FUNCTION=::hello_from_namespace::HelloWorld',
+      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=http',
+      '--env', 'GOOGLE_FUNCTION_TARGET=::hello_from_namespace::HelloWorld',
       '--path', 'examples/hello_from_namespace',
       'hello-from-namespace-rooted',
     ]
@@ -92,8 +92,8 @@ steps:
     waitFor: ['gcf-builder-ready']
     id: 'hello-from-nested-namespace'
     args: ['build',
-      '--env', 'FUNCTION_SIGNATURE_TYPE=http',
-      '--env', 'TARGET_FUNCTION=hello_from_nested_namespace::ns0::ns1::HelloWorld',
+      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=http',
+      '--env', 'GOOGLE_FUNCTION_TARGET=hello_from_nested_namespace::ns0::ns1::HelloWorld',
       '--path', 'examples/hello_from_nested_namespace',
       'hello-from-nested-namespace',
     ]
@@ -102,8 +102,8 @@ steps:
     waitFor: ['gcf-builder-ready']
     id: 'hello-multiple-sources'
     args: ['build',
-      '--env', 'FUNCTION_SIGNATURE_TYPE=http',
-      '--env', 'TARGET_FUNCTION=HelloMultipleSources',
+      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=http',
+      '--env', 'GOOGLE_FUNCTION_TARGET=HelloMultipleSources',
       '--path', 'examples/hello_multiple_sources',
       'hello-multiple-sources',
     ]
@@ -112,8 +112,8 @@ steps:
     waitFor: ['gcf-builder-ready']
     id: 'hello-gcs'
     args: ['build',
-      '--env', 'FUNCTION_SIGNATURE_TYPE=http',
-      '--env', 'TARGET_FUNCTION=HelloGcs',
+      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=http',
+      '--env', 'GOOGLE_FUNCTION_TARGET=HelloGcs',
       '--path', 'examples/hello_gcs',
       'hello-gcs',
     ]
@@ -122,8 +122,8 @@ steps:
     waitFor: ['gcf-builder-ready']
     id: 'hello-with-third-party'
     args: ['build',
-      '--env', 'FUNCTION_SIGNATURE_TYPE=http',
-      '--env', 'TARGET_FUNCTION=HelloWithThirdParty',
+      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=http',
+      '--env', 'GOOGLE_FUNCTION_TARGET=HelloWithThirdParty',
       '--path', 'examples/hello_with_third_party',
       'hello-with-third-party',
     ]
@@ -132,8 +132,8 @@ steps:
     waitFor: ['gcf-builder-ready']
     id: 'hello-world'
     args: ['build',
-      '--env', 'FUNCTION_SIGNATURE_TYPE=http',
-      '--env', 'TARGET_FUNCTION=HelloWorld',
+      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=http',
+      '--env', 'GOOGLE_FUNCTION_TARGET=HelloWorld',
       '--path', 'examples/hello_world',
       'hello-world',
     ]
@@ -142,8 +142,8 @@ steps:
     waitFor: ['gcf-builder-ready']
     id: 'hello-world-rooted'
     args: ['build',
-      '--env', 'FUNCTION_SIGNATURE_TYPE=http',
-      '--env', 'TARGET_FUNCTION=::HelloWorld',
+      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=http',
+      '--env', 'GOOGLE_FUNCTION_TARGET=::HelloWorld',
       '--path', 'examples/hello_world',
       'hello-world-rooted',
     ]
@@ -152,8 +152,8 @@ steps:
     waitFor: ['gcf-builder-ready']
     id: 'howto-use-legacy-code'
     args: ['build',
-      '--env', 'FUNCTION_SIGNATURE_TYPE=http',
-      '--env', 'TARGET_FUNCTION=HowtoUseLegacyCode',
+      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=http',
+      '--env', 'GOOGLE_FUNCTION_TARGET=HowtoUseLegacyCode',
       '--path', 'examples/howto_use_legacy_code',
       'howto-use-legacy-code',
     ]
@@ -163,8 +163,8 @@ steps:
     waitFor: ['gcf-builder-ready']
     id: 'site-bearer_token'
     args: ['build',
-      '--env', 'FUNCTION_SIGNATURE_TYPE=http',
-      '--env', 'TARGET_FUNCTION=bearer_token',
+      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=http',
+      '--env', 'GOOGLE_FUNCTION_TARGET=bearer_token',
       '--path', 'examples/site/bearer_token',
       'site-bearer_token',
     ]
@@ -172,8 +172,8 @@ steps:
     waitFor: ['gcf-builder-ready']
     id: 'site-concepts_after_response'
     args: ['build',
-      '--env', 'FUNCTION_SIGNATURE_TYPE=http',
-      '--env', 'TARGET_FUNCTION=concepts_after_response',
+      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=http',
+      '--env', 'GOOGLE_FUNCTION_TARGET=concepts_after_response',
       '--path', 'examples/site/concepts_after_response',
       'site-concepts_after_response',
     ]
@@ -181,8 +181,8 @@ steps:
     waitFor: ['gcf-builder-ready']
     id: 'site-concepts_after_timeout'
     args: ['build',
-      '--env', 'FUNCTION_SIGNATURE_TYPE=http',
-      '--env', 'TARGET_FUNCTION=concepts_after_timeout',
+      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=http',
+      '--env', 'GOOGLE_FUNCTION_TARGET=concepts_after_timeout',
       '--path', 'examples/site/concepts_after_timeout',
       'site-concepts_after_timeout',
     ]
@@ -190,8 +190,8 @@ steps:
     waitFor: ['gcf-builder-ready']
     id: 'site-concepts_filesystem'
     args: ['build',
-      '--env', 'FUNCTION_SIGNATURE_TYPE=http',
-      '--env', 'TARGET_FUNCTION=concepts_filesystem',
+      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=http',
+      '--env', 'GOOGLE_FUNCTION_TARGET=concepts_filesystem',
       '--path', 'examples/site/concepts_filesystem',
       'site-concepts_filesystem',
     ]
@@ -199,8 +199,8 @@ steps:
     waitFor: ['gcf-builder-ready']
     id: 'site-concepts_request'
     args: ['build',
-      '--env', 'FUNCTION_SIGNATURE_TYPE=http',
-      '--env', 'TARGET_FUNCTION=concepts_request',
+      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=http',
+      '--env', 'GOOGLE_FUNCTION_TARGET=concepts_request',
       '--path', 'examples/site/concepts_request',
       'site-concepts_request',
     ]
@@ -208,8 +208,8 @@ steps:
     waitFor: ['gcf-builder-ready']
     id: 'site-concepts_stateless'
     args: ['build',
-      '--env', 'FUNCTION_SIGNATURE_TYPE=http',
-      '--env', 'TARGET_FUNCTION=concepts_stateless',
+      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=http',
+      '--env', 'GOOGLE_FUNCTION_TARGET=concepts_stateless',
       '--path', 'examples/site/concepts_stateless',
       'site-concepts_stateless',
     ]
@@ -217,8 +217,8 @@ steps:
     waitFor: ['gcf-builder-ready']
     id: 'site-env_vars'
     args: ['build',
-      '--env', 'FUNCTION_SIGNATURE_TYPE=http',
-      '--env', 'TARGET_FUNCTION=env_vars',
+      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=http',
+      '--env', 'GOOGLE_FUNCTION_TARGET=env_vars',
       '--path', 'examples/site/env_vars',
       'site-env_vars',
     ]
@@ -226,8 +226,8 @@ steps:
     waitFor: ['gcf-builder-ready']
     id: 'site-hello_world_error'
     args: ['build',
-      '--env', 'FUNCTION_SIGNATURE_TYPE=http',
-      '--env', 'TARGET_FUNCTION=hello_world_error',
+      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=http',
+      '--env', 'GOOGLE_FUNCTION_TARGET=hello_world_error',
       '--path', 'examples/site/hello_world_error',
       'site-hello_world_error',
     ]
@@ -235,8 +235,8 @@ steps:
     waitFor: ['gcf-builder-ready']
     id: 'site-hello_world_get'
     args: ['build',
-      '--env', 'FUNCTION_SIGNATURE_TYPE=http',
-      '--env', 'TARGET_FUNCTION=hello_world_get',
+      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=http',
+      '--env', 'GOOGLE_FUNCTION_TARGET=hello_world_get',
       '--path', 'examples/site/hello_world_get',
       'site-hello_world_get',
     ]
@@ -244,8 +244,8 @@ steps:
     waitFor: ['gcf-builder-ready']
     id: 'site-hello_world_http'
     args: ['build',
-      '--env', 'FUNCTION_SIGNATURE_TYPE=http',
-      '--env', 'TARGET_FUNCTION=hello_world_http',
+      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=http',
+      '--env', 'GOOGLE_FUNCTION_TARGET=hello_world_http',
       '--path', 'examples/site/hello_world_http',
       'site-hello_world_http',
     ]
@@ -253,8 +253,8 @@ steps:
     waitFor: ['gcf-builder-ready']
     id: 'site-hello_world_pubsub'
     args: ['build',
-      '--env', 'FUNCTION_SIGNATURE_TYPE=cloudevent',
-      '--env', 'TARGET_FUNCTION=hello_world_pubsub',
+      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=cloudevent',
+      '--env', 'GOOGLE_FUNCTION_TARGET=hello_world_pubsub',
       '--path', 'examples/site/hello_world_pubsub',
       'site-hello_world_pubsub',
     ]
@@ -262,8 +262,8 @@ steps:
     waitFor: ['gcf-builder-ready']
     id: 'site-hello_world_storage'
     args: ['build',
-      '--env', 'FUNCTION_SIGNATURE_TYPE=cloudevent',
-      '--env', 'TARGET_FUNCTION=hello_world_storage',
+      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=cloudevent',
+      '--env', 'GOOGLE_FUNCTION_TARGET=hello_world_storage',
       '--path', 'examples/site/hello_world_storage',
       'site-hello_world_storage',
     ]
@@ -271,8 +271,8 @@ steps:
     waitFor: ['gcf-builder-ready']
     id: 'site-http_content'
     args: ['build',
-      '--env', 'FUNCTION_SIGNATURE_TYPE=http',
-      '--env', 'TARGET_FUNCTION=http_content',
+      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=http',
+      '--env', 'GOOGLE_FUNCTION_TARGET=http_content',
       '--path', 'examples/site/http_content',
       'site-http_content',
     ]
@@ -280,8 +280,8 @@ steps:
     waitFor: ['gcf-builder-ready']
     id: 'site-http_cors'
     args: ['build',
-      '--env', 'FUNCTION_SIGNATURE_TYPE=http',
-      '--env', 'TARGET_FUNCTION=http_cors',
+      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=http',
+      '--env', 'GOOGLE_FUNCTION_TARGET=http_cors',
       '--path', 'examples/site/http_cors',
       'site-http_cors',
     ]
@@ -289,8 +289,8 @@ steps:
     waitFor: ['gcf-builder-ready']
     id: 'site-http_cors_auth'
     args: ['build',
-      '--env', 'FUNCTION_SIGNATURE_TYPE=http',
-      '--env', 'TARGET_FUNCTION=http_cors_auth',
+      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=http',
+      '--env', 'GOOGLE_FUNCTION_TARGET=http_cors_auth',
       '--path', 'examples/site/http_cors_auth',
       'site-http_cors_auth',
     ]
@@ -298,8 +298,8 @@ steps:
     waitFor: ['gcf-builder-ready']
     id: 'site-http_form_data'
     args: ['build',
-      '--env', 'FUNCTION_SIGNATURE_TYPE=http',
-      '--env', 'TARGET_FUNCTION=http_form_data',
+      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=http',
+      '--env', 'GOOGLE_FUNCTION_TARGET=http_form_data',
       '--path', 'examples/site/http_form_data',
       'site-http_form_data',
     ]
@@ -307,8 +307,8 @@ steps:
     waitFor: ['gcf-builder-ready']
     id: 'site-http_method'
     args: ['build',
-      '--env', 'FUNCTION_SIGNATURE_TYPE=http',
-      '--env', 'TARGET_FUNCTION=http_method',
+      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=http',
+      '--env', 'GOOGLE_FUNCTION_TARGET=http_method',
       '--path', 'examples/site/http_method',
       'site-http_method',
     ]
@@ -316,8 +316,8 @@ steps:
     waitFor: ['gcf-builder-ready']
     id: 'site-http_xml'
     args: ['build',
-      '--env', 'FUNCTION_SIGNATURE_TYPE=http',
-      '--env', 'TARGET_FUNCTION=http_xml',
+      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=http',
+      '--env', 'GOOGLE_FUNCTION_TARGET=http_xml',
       '--path', 'examples/site/http_xml',
       'site-http_xml',
     ]
@@ -325,8 +325,8 @@ steps:
     waitFor: ['gcf-builder-ready']
     id: 'site-log_helloworld'
     args: ['build',
-      '--env', 'FUNCTION_SIGNATURE_TYPE=http',
-      '--env', 'TARGET_FUNCTION=log_helloworld',
+      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=http',
+      '--env', 'GOOGLE_FUNCTION_TARGET=log_helloworld',
       '--path', 'examples/site/log_helloworld',
       'site-log_helloworld',
     ]
@@ -334,8 +334,8 @@ steps:
     waitFor: ['gcf-builder-ready']
     id: 'site-log_stackdriver'
     args: ['build',
-      '--env', 'FUNCTION_SIGNATURE_TYPE=cloudevent',
-      '--env', 'TARGET_FUNCTION=log_stackdriver',
+      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=cloudevent',
+      '--env', 'GOOGLE_FUNCTION_TARGET=log_stackdriver',
       '--path', 'examples/site/log_stackdriver',
       'site-log_stackdriver',
     ]
@@ -343,8 +343,8 @@ steps:
     waitFor: ['gcf-builder-ready']
     id: 'site-pubsub_subscribe'
     args: ['build',
-      '--env', 'FUNCTION_SIGNATURE_TYPE=cloudevent',
-      '--env', 'TARGET_FUNCTION=pubsub_subscribe',
+      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=cloudevent',
+      '--env', 'GOOGLE_FUNCTION_TARGET=pubsub_subscribe',
       '--path', 'examples/site/pubsub_subscribe',
       'site-pubsub_subscribe',
     ]
@@ -352,8 +352,8 @@ steps:
     waitFor: ['gcf-builder-ready']
     id: 'site-tips_gcp_apis'
     args: ['build',
-      '--env', 'FUNCTION_SIGNATURE_TYPE=http',
-      '--env', 'TARGET_FUNCTION=tips_gcp_apis',
+      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=http',
+      '--env', 'GOOGLE_FUNCTION_TARGET=tips_gcp_apis',
       '--path', 'examples/site/tips_gcp_apis',
       'site-tips_gcp_apis',
     ]
@@ -361,8 +361,8 @@ steps:
     waitFor: ['gcf-builder-ready']
     id: 'site-tips_infinite_retries'
     args: ['build',
-      '--env', 'FUNCTION_SIGNATURE_TYPE=cloudevent',
-      '--env', 'TARGET_FUNCTION=tips_infinite_retries',
+      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=cloudevent',
+      '--env', 'GOOGLE_FUNCTION_TARGET=tips_infinite_retries',
       '--path', 'examples/site/tips_infinite_retries',
       'site-tips_infinite_retries',
     ]
@@ -370,8 +370,8 @@ steps:
     waitFor: ['gcf-builder-ready']
     id: 'site-tips_lazy_globals'
     args: ['build',
-      '--env', 'FUNCTION_SIGNATURE_TYPE=http',
-      '--env', 'TARGET_FUNCTION=tips_lazy_globals',
+      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=http',
+      '--env', 'GOOGLE_FUNCTION_TARGET=tips_lazy_globals',
       '--path', 'examples/site/tips_lazy_globals',
       'site-tips_lazy_globals',
     ]
@@ -379,8 +379,8 @@ steps:
     waitFor: ['gcf-builder-ready']
     id: 'site-tips_retry'
     args: ['build',
-      '--env', 'FUNCTION_SIGNATURE_TYPE=cloudevent',
-      '--env', 'TARGET_FUNCTION=tips_retry',
+      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=cloudevent',
+      '--env', 'GOOGLE_FUNCTION_TARGET=tips_retry',
       '--path', 'examples/site/tips_retry',
       'site-tips_retry',
     ]
@@ -388,8 +388,8 @@ steps:
     waitFor: ['gcf-builder-ready']
     id: 'site-tips_scopes'
     args: ['build',
-      '--env', 'FUNCTION_SIGNATURE_TYPE=http',
-      '--env', 'TARGET_FUNCTION=tips_scopes',
+      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=http',
+      '--env', 'GOOGLE_FUNCTION_TARGET=tips_scopes',
       '--path', 'examples/site/tips_scopes',
       'site-tips_scopes',
     ]
@@ -397,8 +397,8 @@ steps:
     waitFor: ['gcf-builder-ready']
     id: 'site-tutorial_cloud_bigtable'
     args: ['build',
-      '--env', 'FUNCTION_SIGNATURE_TYPE=http',
-      '--env', 'TARGET_FUNCTION=tutorial_cloud_bigtable',
+      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=http',
+      '--env', 'GOOGLE_FUNCTION_TARGET=tutorial_cloud_bigtable',
       '--path', 'examples/site/tutorial_cloud_bigtable',
       'site-tutorial_cloud_bigtable',
     ]
@@ -406,8 +406,8 @@ steps:
     waitFor: ['gcf-builder-ready']
     id: 'site-tutorial_cloud_spanner'
     args: ['build',
-      '--env', 'FUNCTION_SIGNATURE_TYPE=http',
-      '--env', 'TARGET_FUNCTION=tutorial_cloud_spanner',
+      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=http',
+      '--env', 'GOOGLE_FUNCTION_TARGET=tutorial_cloud_spanner',
       '--path', 'examples/site/tutorial_cloud_spanner',
       'site-tutorial_cloud_spanner',
     ]

--- a/ci/generate-build-examples.sh
+++ b/ci/generate-build-examples.sh
@@ -92,8 +92,8 @@ generic_example() {
     waitFor: ['gcf-builder-ready']
     id: '${container}'
     args: ['build',
-      '--env', 'FUNCTION_SIGNATURE_TYPE=${signature}',
-      '--env', 'TARGET_FUNCTION=${function}',
+      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=${signature}',
+      '--env', 'GOOGLE_FUNCTION_TARGET=${function}',
       '--path', 'examples/${example}',
       '${container}',
     ]
@@ -115,8 +115,8 @@ site_example() {
     waitFor: ['gcf-builder-ready']
     id: '${container}'
     args: ['build',
-      '--env', 'FUNCTION_SIGNATURE_TYPE=${signature}',
-      '--env', 'TARGET_FUNCTION=${function}',
+      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=${signature}',
+      '--env', 'GOOGLE_FUNCTION_TARGET=${function}',
       '--path', '${example}',
       '${container}',
     ]

--- a/ci/pack/buildpack/bin/build
+++ b/ci/pack/buildpack/bin/build
@@ -233,7 +233,7 @@ generate_main() {
 }
 
 generate_main \
-    "${TARGET_FUNCTION}" "${FUNCTION_SIGNATURE_TYPE:-http}" >"${layers}/source/main.cc"
+    "${GOOGLE_FUNCTION_TARGET}" "${GOOGLE_FUNCTION_SIGNATURE_TYPE:-http}" >"${layers}/source/main.cc"
 
 echo "-----> Configure Function"
 cat >"${layers}/binary.toml" <<_EOF_

--- a/examples/README.md
+++ b/examples/README.md
@@ -41,8 +41,8 @@ Compile any HTTP example using:
 
 ```sh
 pack build "my-image" \
-  --env TARGET_FUNCTION=$EXAMPLE_FUNCTION_NAME \
-  --env FUNCTION_SIGNATURE_TYPE=http \
+  --env GOOGLE_FUNCTION_TARGET=$EXAMPLE_FUNCTION_NAME \
+  --env GOOGLE_FUNCTION_SIGNATURE_TYPE=http \
   --path examples/$EXAMPLE_DIRECTORY
 ```
 
@@ -50,8 +50,8 @@ for example:
 
 ```sh
 pack build "hello-world" \
-  --env TARGET_FUNCTION=HelloWorld \
-  --env FUNCTION_SIGNATURE_TYPE=http \
+  --env GOOGLE_FUNCTION_TARGET=HelloWorld \
+  --env GOOGLE_FUNCTION_SIGNATURE_TYPE=http \
   --path examples/hello_world
 ```
 
@@ -76,8 +76,8 @@ Create the Docker image, with a tag suitable for deployment to Cloud Run:
 
 ```sh
 pack build "gcr.io/${GOOGLE_CLOUD_PROJECT}/hello-world" \
-  --env TARGET_FUNCTION=HelloWorld \
-  --env FUNCTION_SIGNATURE_TYPE=http \
+  --env GOOGLE_FUNCTION_TARGET=HelloWorld \
+  --env GOOGLE_FUNCTION_SIGNATURE_TYPE=http \
   --path examples/hello_world
 ```
 

--- a/examples/site/howto_offload_builder_creation/README.md
+++ b/examples/site/howto_offload_builder_creation/README.md
@@ -98,8 +98,8 @@ Build a Docker image from your function using this buildpack:
 ```shell
 pack build \
     --builder gcr.io/${GOOGLE_CLOUD_PROJECT}/functions-framework-cpp/builder:bionic \
-    --env FUNCTION_SIGNATURE_TYPE=http \
-    --env TARGET_FUNCTION=hello_world_http \
+    --env GOOGLE_FUNCTION_SIGNATURE_TYPE=http \
+    --env GOOGLE_FUNCTION_TARGET=hello_world_http \
     --path examples/site/hello_world_http \
     gcf-cpp-hello-world-http
 ```
@@ -116,8 +116,8 @@ Then the command becomes:
 
 ```shell
 pack build \
-    --env FUNCTION_SIGNATURE_TYPE=http \
-    --env TARGET_FUNCTION=hello_world_http \
+    --env GOOGLE_FUNCTION_SIGNATURE_TYPE=http \
+    --env GOOGLE_FUNCTION_TARGET=hello_world_http \
     --path examples/site/hello_world_http \
     gcf-cpp-hello-world-http
 ```

--- a/examples/site/testing_pubsub/README.md
+++ b/examples/site/testing_pubsub/README.md
@@ -68,8 +68,8 @@ This guide assumes that you have:
 ```shell
 pack build \
     --builder gcf-cpp-builder:bionic \
-    --env "FUNCTION_SIGNATURE_TYPE=cloudevent" \
-    --env "TARGET_FUNCTION=hello_world_pubsub" \
+    --env "GOOGLE_FUNCTION_SIGNATURE_TYPE=cloudevent" \
+    --env "GOOGLE_FUNCTION_TARGET=hello_world_pubsub" \
     --path "examples/site/hello_world_pubsub" \
     "gcr.io/${GOOGLE_CLOUD_PROJECT}/gcf-hello-world-pubsub"
 ```

--- a/pack/buildpack/bin/build
+++ b/pack/buildpack/bin/build
@@ -233,7 +233,7 @@ generate_main() {
 }
 
 generate_main \
-    "${TARGET_FUNCTION}" "${FUNCTION_SIGNATURE_TYPE:-http}" >"${layers}/source/main.cc"
+    "${GOOGLE_FUNCTION_TARGET}" "${GOOGLE_FUNCTION_SIGNATURE_TYPE:-http}" >"${layers}/source/main.cc"
 
 echo "-----> Configure Function"
 cat >"${layers}/binary.toml" <<_EOF_


### PR DESCRIPTION
To validate the framework we create our own buildpack and use it to
build the examples. With this change the buildpack uses `GOOGLE_`
prefixes for the environment variables controlling its behavior, which
matches how the official buildpacks are controlled:

https://github.com/GoogleCloudPlatform/buildpacks#functions-framework-buildpacks