### PR TITLE
chore: update .dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,8 @@
 # Common build output directory names
 .build/
 _build/
+cmake-out/
+build-out/
 
 # Used by some IDEs and LSP plugins
 compile_commands.json


### PR DESCRIPTION
Add some directories that appear as part of local GCB builds, this
speeds up local testing of buildpacks and other Docker-based workflows.