### PR TITLE
ci: update GCB scripts to use BuildKit

### DIFF
--- a/ci/cloudbuild/builds/check-api.sh
+++ b/ci/cloudbuild/builds/check-api.sh
@@ -32,6 +32,7 @@ vcpkg_root="$(vcpkg::root_dir)"
 io::log_h2 "Configuring, building, and installing the C++ Functions Framework"
 cmake -GNinja \
   -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
+  -DCMAKE_INSTALL_MESSAGE=NEVER \
   -DBUILD_SHARED_LIBS=ON \
   -DCMAKE_BUILD_TYPE=Debug \
   -DCMAKE_CXX_FLAGS="-Og -Wno-maybe-uninitialized" \
@@ -39,7 +40,7 @@ cmake -GNinja \
   -DVCPKG_FEATURE_FLAGS="versions,manifest" \
   -S . -B cmake-out
 cmake --build cmake-out
-cmake --build cmake-out --target install
+cmake --install cmake-out
 
 # Uses `abi-dumper` to dump the ABI for the given library, which should be
 # installed at the given prefix. This function will be called from a subshell,


### PR DESCRIPTION
Use Docker BuildKit to create the build image. Rename the build image to
avoid conflicts with the images used in `google-cloud-cpp`, sometimes In
need to use both in my workstation, more or less at the same time.