### PR TITLE
ci: support declarative functions in examples

### DIFF
--- a/ci/generate-build-examples.sh
+++ b/ci/generate-build-examples.sh
@@ -87,12 +87,17 @@ generic_example() {
     container="${4}"
   fi
 
+  local signature_arg=""
+  if [[ "${signature}" != "declarative" ]] && [[ "${signature}" != "" ]]; then
+    signature_arg="'--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=${signature}',"
+  fi
+
   cat <<_EOF_
   - name: 'pack'
     waitFor: ['gcf-builder-ready']
     id: '${container}'
     args: ['build',
-      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=${signature}',
+      ${signature_arg}
       '--env', 'GOOGLE_FUNCTION_TARGET=${function}',
       '--path', 'examples/${example}',
       '${container}',
@@ -110,12 +115,17 @@ site_example() {
     signature="cloudevent"
   fi
   local container="site-${function}"
+  local signature_arg=""
+  if [[ "${signature}" != "declarative" ]] && [[ "${signature}" != "" ]]; then
+    signature_arg="'--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=${signature}',"
+  fi
+
   cat <<_EOF_
   - name: 'pack'
     waitFor: ['gcf-builder-ready']
     id: '${container}'
     args: ['build',
-      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=${signature}',
+      ${signature_arg}
       '--env', 'GOOGLE_FUNCTION_TARGET=${function}',
       '--path', '${example}',
       '${container}',
@@ -128,7 +138,7 @@ generic_example hello_from_namespace hello_from_namespace::HelloWorld http
 generic_example hello_from_namespace ::hello_from_namespace::HelloWorld http hello-from-namespace-rooted
 generic_example hello_from_nested_namespace hello_from_nested_namespace::ns0::ns1::HelloWorld http
 generic_example hello_multiple_sources HelloMultipleSources http
-generic_example hello_gcs HelloGcs http
+generic_example hello_gcs HelloGcs declarative
 generic_example hello_with_third_party HelloWithThirdParty http
 generic_example hello_world HelloWorld http
 generic_example hello_world ::HelloWorld http hello-world-rooted

--- a/ci/pack/buildpack/bin/build
+++ b/ci/pack/buildpack/bin/build
@@ -130,11 +130,8 @@ generate_http_main_no_namespace() {
   local function="${1}"
   cat <<_EOF_
 #include <google/cloud/functions/framework.h>
-
 namespace gcf = ::google::cloud::functions;
-
 extern gcf::HttpResponse ${function}(gcf::HttpRequest);
-
 int main(int argc, char* argv[]) {
   return gcf::Run(argc, argv, gcf::UserHttpFunction(${function}));
 }
@@ -147,13 +144,10 @@ generate_http_main_with_namespace() {
 
   cat <<_EOF_
 #include <google/cloud/functions/framework.h>
-
 namespace gcf = ::google::cloud::functions;
-
 namespace ${namespace} {
   extern gcf::HttpResponse ${function}(gcf::HttpRequest);
 } // namespace
-
 int main(int argc, char* argv[]) {
   return gcf::Run(argc, argv, gcf::UserHttpFunction(::${namespace}::${function}));
 }
@@ -164,11 +158,8 @@ generate_cloud_event_main_no_namespace() {
   local function="${1}"
   cat <<_EOF_
 #include <google/cloud/functions/framework.h>
-
 namespace gcf = ::google::cloud::functions;
-
 extern void ${function}(gcf::CloudEvent);
-
 int main(int argc, char* argv[]) {
   return gcf::Run(argc, argv, gcf::UserCloudEventFunction(${function}));
 }
@@ -181,15 +172,43 @@ generate_cloud_event_main_with_namespace() {
 
   cat <<_EOF_
 #include <google/cloud/functions/framework.h>
-
 namespace gcf = ::google::cloud::functions;
-
 namespace ${namespace} {
   extern void ${function}(gcf::CloudEvent);
 } // namespace
-
 int main(int argc, char* argv[]) {
   return gcf::Run(argc, argv, gcf::UserCloudEventFunction(::${namespace}::${function}));
+}
+_EOF_
+}
+
+generate_declarative_main_no_namespace() {
+  local function="${1}"
+  cat <<_EOF_
+#include <google/cloud/functions/framework.h>
+#include <google/cloud/functions/function.h>
+namespace gcf = ::google::cloud::functions;
+extern gcf::Function ${function}();
+int main(int argc, char* argv[]) {
+  return gcf::Run(argc, argv, ${function}());
+}
+_EOF_
+}
+
+generate_cloud_event_main_with_namespace() {
+  local function="${1}"
+  local namespace="${2}"
+
+  cat <<_EOF_
+#include <google/cloud/functions/framework.h>
+#include <google/cloud/functions/function.h>
+namespace gcf = ::google::cloud::functions;
+namespace ${namespace} {
+  extern gcf::Function ${function}();
+} // namespace
+
+int main(int argc, char* argv[]) {
+  return gcf::Run(argc, argv, ::${namespace}::${function}());
 }
 _EOF_
 }
@@ -224,12 +243,21 @@ generate_main() {
     return
   fi
 
+  if [[ "${signature}" == "declarative" ]] || [[ "${signature}" == "" ]]; then
+    if [[ -z "${namespace}" || "${namespace}" == "." ]]; then
+      generate_declarative_main_no_namespace "${function}"
+      return
+    fi
+    generate_declarative_main_with_namespace "${function}" "${namespace}"
+    return
+  fi
+
   >&2 echo "Unknown function signature type: ${signature}"
   exit 1
 }
 
 generate_main \
-    "${GOOGLE_FUNCTION_TARGET}" "${GOOGLE_FUNCTION_SIGNATURE_TYPE:-http}" >"${layers}/source/main.cc"
+    "${GOOGLE_FUNCTION_TARGET}" "${GOOGLE_FUNCTION_SIGNATURE_TYPE:-}" >"${layers}/source/main.cc"
 
 echo "-----> Configure Function"
 cat >"${layers}/binary.toml" <<_EOF_

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,14 +16,13 @@ Functions Framework for C++. The main audience for these notes are developers
 ## Create the Development and Runtime Docker Images
 
 These notes assume the reader is familiar with GCP, the Google Cloud SDK
-command-line tool, and with the `docker(1)`
-command-line tool.
+command-line tool, and with the `docker(1)` command-line tool.
 
 To compile the examples you will need a Docker image with the development tools
 and core dependencies pre-compiled. To create this image run this command:
 
 ```sh
-docker build -t ci-build-image --target gcf-cpp-develop -f build_scripts/Dockerfile .
+docker build -t ci-build-image --target gcf-cpp-ci -f build_scripts/Dockerfile .
 ```
 
 The runtime image is contains just the minimal components to execute a program


### PR DESCRIPTION
This changes the buildpack use in our CI builds to support declarative
functions. I modified a single example to show that this works, and
updated the instructions to use the right buildpack.

Part of the work for #345 