### PR TITLE
doc: examples use declarative configuration 1/N

### DIFF
--- a/ci/build-examples.yaml
+++ b/ci/build-examples.yaml
@@ -62,7 +62,6 @@ steps:
     waitFor: ['gcf-builder-ready']
     id: 'hello-cloud-event'
     args: ['build',
-      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=cloudevent',
       '--env', 'GOOGLE_FUNCTION_TARGET=HelloCloudEvent',
       '--path', 'examples/hello_cloud_event',
       'hello-cloud-event',
@@ -72,7 +71,6 @@ steps:
     waitFor: ['gcf-builder-ready']
     id: 'hello-from-namespace'
     args: ['build',
-      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=http',
       '--env', 'GOOGLE_FUNCTION_TARGET=hello_from_namespace::HelloWorld',
       '--path', 'examples/hello_from_namespace',
       'hello-from-namespace',
@@ -82,7 +80,6 @@ steps:
     waitFor: ['gcf-builder-ready']
     id: 'hello-from-namespace-rooted'
     args: ['build',
-      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=http',
       '--env', 'GOOGLE_FUNCTION_TARGET=::hello_from_namespace::HelloWorld',
       '--path', 'examples/hello_from_namespace',
       'hello-from-namespace-rooted',
@@ -92,7 +89,6 @@ steps:
     waitFor: ['gcf-builder-ready']
     id: 'hello-from-nested-namespace'
     args: ['build',
-      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=http',
       '--env', 'GOOGLE_FUNCTION_TARGET=hello_from_nested_namespace::ns0::ns1::HelloWorld',
       '--path', 'examples/hello_from_nested_namespace',
       'hello-from-nested-namespace',
@@ -102,7 +98,6 @@ steps:
     waitFor: ['gcf-builder-ready']
     id: 'hello-multiple-sources'
     args: ['build',
-      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=http',
       '--env', 'GOOGLE_FUNCTION_TARGET=HelloMultipleSources',
       '--path', 'examples/hello_multiple_sources',
       'hello-multiple-sources',
@@ -121,7 +116,6 @@ steps:
     waitFor: ['gcf-builder-ready']
     id: 'hello-with-third-party'
     args: ['build',
-      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=http',
       '--env', 'GOOGLE_FUNCTION_TARGET=HelloWithThirdParty',
       '--path', 'examples/hello_with_third_party',
       'hello-with-third-party',
@@ -131,7 +125,6 @@ steps:
     waitFor: ['gcf-builder-ready']
     id: 'hello-world'
     args: ['build',
-      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=http',
       '--env', 'GOOGLE_FUNCTION_TARGET=HelloWorld',
       '--path', 'examples/hello_world',
       'hello-world',
@@ -141,7 +134,6 @@ steps:
     waitFor: ['gcf-builder-ready']
     id: 'hello-world-rooted'
     args: ['build',
-      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=http',
       '--env', 'GOOGLE_FUNCTION_TARGET=::HelloWorld',
       '--path', 'examples/hello_world',
       'hello-world-rooted',
@@ -151,7 +143,6 @@ steps:
     waitFor: ['gcf-builder-ready']
     id: 'howto-use-legacy-code'
     args: ['build',
-      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=http',
       '--env', 'GOOGLE_FUNCTION_TARGET=HowtoUseLegacyCode',
       '--path', 'examples/howto_use_legacy_code',
       'howto-use-legacy-code',

--- a/ci/generate-build-examples.sh
+++ b/ci/generate-build-examples.sh
@@ -132,16 +132,16 @@ _EOF_
 _EOF_
 }
 
-generic_example hello_cloud_event HelloCloudEvent cloudevent
-generic_example hello_from_namespace hello_from_namespace::HelloWorld http
-generic_example hello_from_namespace ::hello_from_namespace::HelloWorld http hello-from-namespace-rooted
-generic_example hello_from_nested_namespace hello_from_nested_namespace::ns0::ns1::HelloWorld http
-generic_example hello_multiple_sources HelloMultipleSources http
+generic_example hello_cloud_event HelloCloudEvent declarative
+generic_example hello_from_namespace hello_from_namespace::HelloWorld declarative
+generic_example hello_from_namespace ::hello_from_namespace::HelloWorld declarative hello-from-namespace-rooted
+generic_example hello_from_nested_namespace hello_from_nested_namespace::ns0::ns1::HelloWorld declarative
+generic_example hello_multiple_sources HelloMultipleSources declarative
 generic_example hello_gcs HelloGcs declarative
-generic_example hello_with_third_party HelloWithThirdParty http
-generic_example hello_world HelloWorld http
-generic_example hello_world ::HelloWorld http hello-world-rooted
-generic_example howto_use_legacy_code HowtoUseLegacyCode http howto-use-legacy-code
+generic_example hello_with_third_party HelloWithThirdParty declarative
+generic_example hello_world HelloWorld declarative
+generic_example hello_world ::HelloWorld declarative hello-world-rooted
+generic_example howto_use_legacy_code HowtoUseLegacyCode declarative howto-use-legacy-code
 
 cat <<_EOF_
   # Build the cloud site examples.

--- a/examples/cloud_event_examples_test.cc
+++ b/examples/cloud_event_examples_test.cc
@@ -12,37 +12,48 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/functions/internal/parse_cloud_event_json.h"
-#include "google/cloud/functions/cloud_event.h"
+#include "google/cloud/functions/internal/function_impl.h"
+#include "google/cloud/functions/function.h"
 #include <gmock/gmock.h>
 
 namespace gcf = ::google::cloud::functions;
+namespace gcf_internal = ::google::cloud::functions_internal;
 
-void HelloCloudEvent(gcf::CloudEvent event);
+gcf::Function HelloCloudEvent();
 
 namespace {
 
-TEST(HttpExamplesTest, HelloCloudEvent) {
-  EXPECT_NO_THROW(HelloCloudEvent(
-      google::cloud::functions_internal::ParseCloudEventJson(R"js({
-    "specversion": "1.0",
-    "type": "google.cloud.pubsub.topic.v1.messagePublished",
-    "source": "//pubsub.googleapis.com/projects/sample-project/topics/gcf-test",
-    "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
-    "subject": "test-only",
-    "time": "2020-09-29T11:32:00.000Z",
-    "datacontenttype": "application/json",
-    "data": {
-      "subscription": "projects/sample-project/subscriptions/sample-subscription",
-      "message": {
-        "@type": "type.googleapis.com/google.pubsub.v1.PubsubMessage",
-        "attributes": {
-           "attr1":"attr1-value"
-        },
-        "data": ""
-      }
+auto constexpr kBody = R"js({
+  "specversion": "1.0",
+  "type": "google.cloud.pubsub.topic.v1.messagePublished",
+  "source": "//pubsub.googleapis.com/projects/sample-project/topics/gcf-test",
+  "id": "aaaaaa-1111-bbbb-2222-cccccccccccc",
+  "subject": "test-only",
+  "time": "2020-09-29T11:32:00.000Z",
+  "datacontenttype": "application/json",
+  "data": {
+    "subscription": "projects/sample-project/subscriptions/sample-subscription",
+    "message": {
+      "@type": "type.googleapis.com/google.pubsub.v1.PubsubMessage",
+      "attributes": {
+         "attr1":"attr1-value"
+      },
+      "data": ""
     }
-  })js")));
+  }
+})js";
+
+TEST(HttpExamplesTest, HelloCloudEvent) {
+  auto function = HelloCloudEvent();
+  gcf_internal::BeastRequest request;
+  request.insert("ce-type", "com.example.someevent");
+  request.insert("ce-source", "/mycontext");
+  request.insert("ce-id", "A234-1234-1234");
+  request.body() = kBody;
+  auto handler =
+      gcf_internal::FunctionImpl::GetImpl(function)->GetHandler("unused");
+  auto const response = handler(std::move(request));
+  EXPECT_EQ(response.result_int(), 200);
 }
 
 }  // namespace

--- a/examples/hello_cloud_event/hello_cloud_event.cc
+++ b/examples/hello_cloud_event/hello_cloud_event.cc
@@ -12,15 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <google/cloud/functions/cloud_event.h>
+#include <google/cloud/functions/function.h>
 #include <iostream>
 
-using ::google::cloud::functions::CloudEvent;
+namespace gcf = ::google::cloud::functions;
 
-// Though not used in this function, `event` is passed by value to support
-// applications that move-out its data.
-void HelloCloudEvent(CloudEvent event) {  // NOLINT
-  std::cout << "Received event"
-            << "\n id: " << event.id()
-            << "\n subject: " << event.subject().value_or("") << std::endl;
+gcf::Function HelloCloudEvent() {
+  return gcf::MakeFunction([](gcf::CloudEvent const& event) {
+    std::cout << "Received event"
+              << "\n id: " << event.id()
+              << "\n subject: " << event.subject().value_or("") << std::endl;
+  });
 }

--- a/examples/hello_from_namespace/hello_from_namespace.cc
+++ b/examples/hello_from_namespace/hello_from_namespace.cc
@@ -12,20 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <google/cloud/functions/http_request.h>
-#include <google/cloud/functions/http_response.h>
+#include <google/cloud/functions/function.h>
 
 namespace hello_from_namespace {
 
-using ::google::cloud::functions::HttpRequest;
-using ::google::cloud::functions::HttpResponse;
+namespace gcf = ::google::cloud::functions;
 
-// Though not used in this example, the request is passed by value to support
-// applications that move-out its data.
-HttpResponse HelloWorld(HttpRequest) {  // NOLINT
-  return HttpResponse{}
-      .set_header("Content-Type", "text/plain")
-      .set_payload("Hello from a C++ namespace!\n");
+gcf::Function HelloWorld() {
+  return gcf::MakeFunction([](gcf::HttpRequest const&) {
+    return gcf::HttpResponse{}
+        .set_header("Content-Type", "text/plain")
+        .set_payload("Hello from a C++ namespace!\n");
+  });
 }
 
 }  // namespace hello_from_namespace

--- a/examples/hello_from_nested_namespace/hello_from_nested_namespace.cc
+++ b/examples/hello_from_nested_namespace/hello_from_nested_namespace.cc
@@ -12,20 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <google/cloud/functions/http_request.h>
-#include <google/cloud/functions/http_response.h>
+#include <google/cloud/functions/function.h>
 
 namespace hello_from_nested_namespace::ns0::ns1 {
 
-using ::google::cloud::functions::HttpRequest;
-using ::google::cloud::functions::HttpResponse;
+namespace gcf = ::google::cloud::functions;
 
-// Though not used in this example, the request is passed by value to support
-// applications that move-out its data.
-HttpResponse HelloWorld(HttpRequest) {  // NOLINT
-  return HttpResponse{}
-      .set_header("Content-Type", "text/plain")
-      .set_payload("Hello from a nested C++ namespace!\n");
+gcf::Function HelloWorld() {
+  return gcf::MakeFunction([](gcf::HttpRequest const&) {
+    return gcf::HttpResponse{}
+        .set_header("Content-Type", "text/plain")
+        .set_payload("Hello from a nested C++ namespace!\n");
+  });
 }
 
 }  // namespace hello_from_nested_namespace::ns0::ns1

--- a/examples/hello_multiple_sources/hello_multiple_sources.cc
+++ b/examples/hello_multiple_sources/hello_multiple_sources.cc
@@ -13,16 +13,14 @@
 // limitations under the License.
 
 #include "greeting.h"
-#include <google/cloud/functions/http_request.h>
-#include <google/cloud/functions/http_response.h>
+#include <google/cloud/functions/function.h>
 
-using ::google::cloud::functions::HttpRequest;
-using ::google::cloud::functions::HttpResponse;
+namespace gcf = ::google::cloud::functions;
 
-// Though not used in this example, the request is passed by value to support
-// applications that move-out its data.
-HttpResponse HelloMultipleSources(HttpRequest) {  // NOLINT
-  return HttpResponse{}
-      .set_header("Content-Type", "text/plain")
-      .set_payload(Greeting());
+gcf::Function HelloMultipleSources() {
+  return gcf::MakeFunction([](gcf::HttpRequest const&) {
+    return gcf::HttpResponse{}
+        .set_header("Content-Type", "text/plain")
+        .set_payload(Greeting());
+  });
 }

--- a/examples/hello_with_third_party/hello_with_third_party.cc
+++ b/examples/hello_with_third_party/hello_with_third_party.cc
@@ -12,17 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <google/cloud/functions/http_request.h>
-#include <google/cloud/functions/http_response.h>
+#include <google/cloud/functions/function.h>
 #include <fmt/core.h>
 
-using ::google::cloud::functions::HttpRequest;
-using ::google::cloud::functions::HttpResponse;
+namespace gcf = ::google::cloud::functions;
 
-// Though not used in this example, the request is passed by value to support
-// applications that move-out its data.
-HttpResponse HelloWithThirdParty(HttpRequest request) {  // NOLINT
-  return HttpResponse{}
-      .set_header("Content-Type", "text/plain")
-      .set_payload(fmt::format("Hello at {}\n", request.target()));
+gcf::Function HelloWithThirdParty() {
+  return gcf::MakeFunction([](gcf::HttpRequest const& request) {
+    return gcf::HttpResponse{}
+        .set_header("Content-Type", "text/plain")
+        .set_payload(fmt::format("Hello at {}\n", request.target()));
+  });
 }

--- a/examples/hello_world/hello_world.cc
+++ b/examples/hello_world/hello_world.cc
@@ -12,16 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <google/cloud/functions/http_request.h>
-#include <google/cloud/functions/http_response.h>
+#include <google/cloud/functions/function.h>
 
-using ::google::cloud::functions::HttpRequest;
-using ::google::cloud::functions::HttpResponse;
+namespace gcf = ::google::cloud::functions;
 
-// Though not used in this example, the request is passed by value to support
-// applications that move-out its data.
-HttpResponse HelloWorld(HttpRequest) {  // NOLINT
-  return HttpResponse{}
-      .set_header("Content-Type", "text/plain")
-      .set_payload("Hello World\n");
+gcf::Function HelloWorld() {
+  return gcf::MakeFunction([](gcf::HttpRequest const&) {
+    return gcf::HttpResponse{}
+        .set_header("Content-Type", "text/plain")
+        .set_payload("Hello World\n");
+  });
 }

--- a/examples/howto_use_legacy_code/howto_use_legacy_code.cc
+++ b/examples/howto_use_legacy_code/howto_use_legacy_code.cc
@@ -13,16 +13,14 @@
 // limitations under the License.
 
 #include "legacy/legacy.h"
-#include <google/cloud/functions/http_request.h>
-#include <google/cloud/functions/http_response.h>
+#include <google/cloud/functions/function.h>
 
-using ::google::cloud::functions::HttpRequest;
-using ::google::cloud::functions::HttpResponse;
+namespace gcf = ::google::cloud::functions;
 
-// Though not used in this example, the request is passed by value to support
-// applications that move-out its data.
-HttpResponse HowtoUseLegacyCode(HttpRequest) {  // NOLINT
-  return HttpResponse{}
-      .set_header("Content-Type", "text/plain")
-      .set_payload(legacy::LegacyMessage());
+gcf::Function HowtoUseLegacyCode() {
+  return gcf::MakeFunction([](gcf::HttpRequest const&) {
+    return gcf::HttpResponse{}
+        .set_header("Content-Type", "text/plain")
+        .set_payload(legacy::LegacyMessage());
+  });
 }

--- a/examples/http_examples_test.cc
+++ b/examples/http_examples_test.cc
@@ -14,7 +14,6 @@
 
 #include <google/cloud/functions/function.h>
 #include <google/cloud/functions/http_request.h>
-#include <google/cloud/functions/http_response.h>
 #include <google/cloud/functions/internal/function_impl.h>
 #include <gmock/gmock.h>
 
@@ -22,17 +21,17 @@ namespace gcf = ::google::cloud::functions;
 namespace gcf_internal = ::google::cloud::functions_internal;
 
 gcf::Function HelloGcs();
-gcf::HttpResponse HelloMultipleSources(gcf::HttpRequest);
-gcf::HttpResponse HelloWithThirdParty(gcf::HttpRequest request);
-gcf::HttpResponse HelloWorld(gcf::HttpRequest);
-gcf::HttpResponse HowtoUseLegacyCode(gcf::HttpRequest);
+gcf::Function HelloMultipleSources();
+gcf::Function HelloWithThirdParty();
+gcf::Function HelloWorld();
+gcf::Function HowtoUseLegacyCode();
 
 namespace hello_from_namespace {
-gcf::HttpResponse HelloWorld(gcf::HttpRequest);
+gcf::Function HelloWorld();
 }  // namespace hello_from_namespace
 
 namespace hello_from_nested_namespace::ns0::ns1 {
-gcf::HttpResponse HelloWorld(gcf::HttpRequest);
+gcf::Function HelloWorld();
 }  // namespace hello_from_nested_namespace::ns0::ns1
 
 namespace {
@@ -46,7 +45,7 @@ auto TriggerFunction(gcf::Function const& function,
 
   auto handler =
       gcf_internal::FunctionImpl::GetImpl(function)->GetHandler("unused");
-  return handler(gcf_internal::BeastRequest{});
+  return handler(std::move(request));
 }
 
 TEST(HttpExamplesTest, HelloGcs) {
@@ -55,35 +54,34 @@ TEST(HttpExamplesTest, HelloGcs) {
 }
 
 TEST(HttpExamplesTest, HelloMultipleSources) {
-  auto const actual = HelloMultipleSources(gcf::HttpRequest{});
-  EXPECT_THAT(actual.payload(), HasSubstr("Hello World"));
+  auto const actual = TriggerFunction(HelloMultipleSources());
+  EXPECT_THAT(actual.body(), HasSubstr("Hello World"));
 }
 
 TEST(HttpExamplesTest, HelloWithThirdParty) {
-  auto const actual =
-      HelloWithThirdParty(gcf::HttpRequest{}.set_target("/here"));
-  EXPECT_THAT(actual.payload(), HasSubstr("Hello at /here"));
+  auto const actual = TriggerFunction(HelloWithThirdParty(), "/here");
+  EXPECT_THAT(actual.body(), HasSubstr("Hello at /here"));
 }
 
 TEST(HttpExamplesTest, HelloWorld) {
-  auto const actual = HelloWorld(gcf::HttpRequest{});
-  EXPECT_THAT(actual.payload(), HasSubstr("Hello World"));
+  auto const actual = TriggerFunction(HelloWorld());
+  EXPECT_THAT(actual.body(), HasSubstr("Hello World"));
 }
 
 TEST(HttpExamplesTest, HelloFromNamespace) {
-  auto const actual = hello_from_namespace::HelloWorld(gcf::HttpRequest{});
-  EXPECT_THAT(actual.payload(), HasSubstr("C++ namespace"));
+  auto const actual = TriggerFunction(hello_from_namespace::HelloWorld());
+  EXPECT_THAT(actual.body(), HasSubstr("C++ namespace"));
 }
 
 TEST(HttpExamplesTest, HelloFromNestedNamespace) {
   auto const actual =
-      hello_from_nested_namespace::ns0::ns1::HelloWorld(gcf::HttpRequest{});
-  EXPECT_THAT(actual.payload(), HasSubstr("C++ namespace"));
+      TriggerFunction(hello_from_nested_namespace::ns0::ns1::HelloWorld());
+  EXPECT_THAT(actual.body(), HasSubstr("C++ namespace"));
 }
 
 TEST(HttpExampleTest, HowtoUseLegacyCode) {
-  auto const actual = HowtoUseLegacyCode(gcf::HttpRequest{});
-  EXPECT_THAT(actual.payload(), HasSubstr("C++"));
+  auto const actual = TriggerFunction(HowtoUseLegacyCode());
+  EXPECT_THAT(actual.body(), HasSubstr("C++"));
 }
 
 }  // namespace


### PR DESCRIPTION
This is the first in a series of PRs to convert all examples to use
declarative configuration for the signature type.

Part of the work for #345 