### PR TITLE
doc: examples use declarative configuration 2/N

### DIFF
--- a/ci/build-examples.yaml
+++ b/ci/build-examples.yaml
@@ -234,7 +234,6 @@ steps:
     waitFor: ['gcf-builder-ready']
     id: 'site-hello_world_http'
     args: ['build',
-      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=http',
       '--env', 'GOOGLE_FUNCTION_TARGET=hello_world_http',
       '--path', 'examples/site/hello_world_http',
       'site-hello_world_http',
@@ -243,7 +242,6 @@ steps:
     waitFor: ['gcf-builder-ready']
     id: 'site-hello_world_pubsub'
     args: ['build',
-      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=cloudevent',
       '--env', 'GOOGLE_FUNCTION_TARGET=hello_world_pubsub',
       '--path', 'examples/site/hello_world_pubsub',
       'site-hello_world_pubsub',
@@ -252,7 +250,6 @@ steps:
     waitFor: ['gcf-builder-ready']
     id: 'site-hello_world_storage'
     args: ['build',
-      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=cloudevent',
       '--env', 'GOOGLE_FUNCTION_TARGET=hello_world_storage',
       '--path', 'examples/site/hello_world_storage',
       'site-hello_world_storage',

--- a/ci/generate-build-examples.sh
+++ b/ci/generate-build-examples.sh
@@ -113,6 +113,9 @@ site_example() {
   if grep -E -q 'gcf::CloudEvent|google::cloud::functions::CloudEvent' ${example}/*; then
     signature="cloudevent"
   fi
+  if grep -E -q 'gcf::Function|google::cloud::functions::Function' ${example}/*; then
+    signature="declarative"
+  fi
   local container="site-${function}"
 
   cat <<_EOF_

--- a/examples/site/hello_world_http/hello_world_http.cc
+++ b/examples/site/hello_world_http/hello_world_http.cc
@@ -13,24 +13,25 @@
 // limitations under the License.
 
 // [START functions_helloworld_http]
-#include <google/cloud/functions/http_request.h>
-#include <google/cloud/functions/http_response.h>
+#include <google/cloud/functions/function.h>
 #include <nlohmann/json.hpp>
 
 namespace gcf = ::google::cloud::functions;
 
-gcf::HttpResponse hello_world_http(gcf::HttpRequest request) {
-  auto greeting = [r = std::move(request)] {
-    auto request_json = nlohmann::json::parse(r.payload(), /*cb=*/nullptr,
-                                              /*allow_exceptions=*/false);
-    if (request_json.count("name") && request_json["name"].is_string()) {
-      return "Hello " + request_json.value("name", "World") + "!";
-    }
-    return std::string("Hello World!");
-  };
+gcf::Function hello_world_http() {
+  return gcf::MakeFunction([](gcf::HttpRequest const& request) {
+    auto greeting = [r = std::move(request)] {
+      auto request_json = nlohmann::json::parse(r.payload(), /*cb=*/nullptr,
+                                                /*allow_exceptions=*/false);
+      if (request_json.count("name") && request_json["name"].is_string()) {
+        return "Hello " + request_json.value("name", "World") + "!";
+      }
+      return std::string("Hello World!");
+    };
 
-  return gcf::HttpResponse{}
-      .set_header("content-type", "text/plain")
-      .set_payload(greeting());
+    return gcf::HttpResponse{}
+        .set_header("content-type", "text/plain")
+        .set_payload(greeting());
+  });
 }
 // [END functions_helloworld_http]

--- a/examples/site/hello_world_http/hello_world_http.cc
+++ b/examples/site/hello_world_http/hello_world_http.cc
@@ -18,20 +18,22 @@
 
 namespace gcf = ::google::cloud::functions;
 
-gcf::Function hello_world_http() {
-  return gcf::MakeFunction([](gcf::HttpRequest const& request) {
-    auto greeting = [r = std::move(request)] {
-      auto request_json = nlohmann::json::parse(r.payload(), /*cb=*/nullptr,
-                                                /*allow_exceptions=*/false);
-      if (request_json.count("name") && request_json["name"].is_string()) {
-        return "Hello " + request_json.value("name", "World") + "!";
-      }
-      return std::string("Hello World!");
-    };
+gcf::HttpResponse hello_world_http_impl(gcf::HttpRequest request) {
+  auto greeting = [r = std::move(request)] {
+    auto request_json = nlohmann::json::parse(r.payload(), /*cb=*/nullptr,
+                                              /*allow_exceptions=*/false);
+    if (request_json.count("name") && request_json["name"].is_string()) {
+      return "Hello " + request_json.value("name", "World") + "!";
+    }
+    return std::string("Hello World!");
+  };
 
-    return gcf::HttpResponse{}
-        .set_header("content-type", "text/plain")
-        .set_payload(greeting());
-  });
+  return gcf::HttpResponse{}
+      .set_header("content-type", "text/plain")
+      .set_payload(greeting());
+}
+
+gcf::Function hello_world_http() {
+  return gcf::MakeFunction(hello_world_http_impl);
 }
 // [END functions_helloworld_http]

--- a/examples/site/hello_world_pubsub/hello_world_pubsub.cc
+++ b/examples/site/hello_world_pubsub/hello_world_pubsub.cc
@@ -20,18 +20,18 @@
 
 namespace gcf = ::google::cloud::functions;
 
-// Though not used in this example, the event is passed by value to support
-// applications that move-out its data.
+void hello_world_pubsub_impl(gcf::CloudEvent const& event) {
+  if (event.data_content_type().value_or("") != "application/json") {
+    BOOST_LOG_TRIVIAL(error) << "expected application/json data";
+    return;
+  }
+  auto const payload = nlohmann::json::parse(event.data().value_or("{}"));
+  auto const name = cppcodec::base64_rfc4648::decode<std::string>(
+      payload["message"]["data"].get<std::string>());
+  BOOST_LOG_TRIVIAL(info) << "Hello " << (name.empty() ? "World" : name);
+}
+
 gcf::Function hello_world_pubsub() {
-  return gcf::MakeFunction([](gcf::CloudEvent const& event) {
-    if (event.data_content_type().value_or("") != "application/json") {
-      BOOST_LOG_TRIVIAL(error) << "expected application/json data";
-      return;
-    }
-    auto const payload = nlohmann::json::parse(event.data().value_or("{}"));
-    auto const name = cppcodec::base64_rfc4648::decode<std::string>(
-        payload["message"]["data"].get<std::string>());
-    BOOST_LOG_TRIVIAL(info) << "Hello " << (name.empty() ? "World" : name);
-  });
+  return gcf::MakeFunction(hello_world_pubsub_impl);
 }
 // [END functions_helloworld_pubsub]

--- a/examples/site/hello_world_pubsub/hello_world_pubsub.cc
+++ b/examples/site/hello_world_pubsub/hello_world_pubsub.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // [START functions_helloworld_pubsub]
-#include <google/cloud/functions/cloud_event.h>
+#include <google/cloud/functions/function.h>
 #include <boost/log/trivial.hpp>
 #include <cppcodec/base64_rfc4648.hpp>
 #include <nlohmann/json.hpp>
@@ -22,14 +22,16 @@ namespace gcf = ::google::cloud::functions;
 
 // Though not used in this example, the event is passed by value to support
 // applications that move-out its data.
-void hello_world_pubsub(gcf::CloudEvent event) {  // NOLINT
-  if (event.data_content_type().value_or("") != "application/json") {
-    BOOST_LOG_TRIVIAL(error) << "expected application/json data";
-    return;
-  }
-  auto const payload = nlohmann::json::parse(event.data().value_or("{}"));
-  auto const name = cppcodec::base64_rfc4648::decode<std::string>(
-      payload["message"]["data"].get<std::string>());
-  BOOST_LOG_TRIVIAL(info) << "Hello " << (name.empty() ? "World" : name);
+gcf::Function hello_world_pubsub() {
+  return gcf::MakeFunction([](gcf::CloudEvent const& event) {
+    if (event.data_content_type().value_or("") != "application/json") {
+      BOOST_LOG_TRIVIAL(error) << "expected application/json data";
+      return;
+    }
+    auto const payload = nlohmann::json::parse(event.data().value_or("{}"));
+    auto const name = cppcodec::base64_rfc4648::decode<std::string>(
+        payload["message"]["data"].get<std::string>());
+    BOOST_LOG_TRIVIAL(info) << "Hello " << (name.empty() ? "World" : name);
+  });
 }
 // [END functions_helloworld_pubsub]

--- a/examples/site/hello_world_storage/hello_world_storage.cc
+++ b/examples/site/hello_world_storage/hello_world_storage.cc
@@ -19,23 +19,23 @@
 
 namespace gcf = ::google::cloud::functions;
 
-// Though not used in this example, the event is passed by value to support
-// applications that move-out its data.
+void hello_world_storage_impl(gcf::CloudEvent const& event) {
+  if (event.data_content_type().value_or("") != "application/json") {
+    BOOST_LOG_TRIVIAL(error) << "expected application/json data";
+    return;
+  }
+  auto const payload = nlohmann::json::parse(event.data().value_or("{}"));
+  BOOST_LOG_TRIVIAL(info) << "Event: " << event.id();
+  BOOST_LOG_TRIVIAL(info) << "Event Type: " << event.type();
+  BOOST_LOG_TRIVIAL(info) << "Bucket: " << payload.value("bucket", "");
+  BOOST_LOG_TRIVIAL(info) << "Object: " << payload.value("name", "");
+  BOOST_LOG_TRIVIAL(info) << "Metageneration: "
+                          << payload.value("metageneration", "");
+  BOOST_LOG_TRIVIAL(info) << "Created: " << payload.value("timeCreated", "");
+  BOOST_LOG_TRIVIAL(info) << "Updated: " << payload.value("updated", "");
+}
+
 gcf::Function hello_world_storage() {
-  return gcf::MakeFunction([](gcf::CloudEvent const& event) {
-    if (event.data_content_type().value_or("") != "application/json") {
-      BOOST_LOG_TRIVIAL(error) << "expected application/json data";
-      return;
-    }
-    auto const payload = nlohmann::json::parse(event.data().value_or("{}"));
-    BOOST_LOG_TRIVIAL(info) << "Event: " << event.id();
-    BOOST_LOG_TRIVIAL(info) << "Event Type: " << event.type();
-    BOOST_LOG_TRIVIAL(info) << "Bucket: " << payload.value("bucket", "");
-    BOOST_LOG_TRIVIAL(info) << "Object: " << payload.value("name", "");
-    BOOST_LOG_TRIVIAL(info)
-        << "Metageneration: " << payload.value("metageneration", "");
-    BOOST_LOG_TRIVIAL(info) << "Created: " << payload.value("timeCreated", "");
-    BOOST_LOG_TRIVIAL(info) << "Updated: " << payload.value("updated", "");
-  });
+  return gcf::MakeFunction(hello_world_storage_impl);
 }
 // [END functions_helloworld_storage]

--- a/examples/site/hello_world_storage/hello_world_storage.cc
+++ b/examples/site/hello_world_storage/hello_world_storage.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // [START functions_helloworld_storage]
-#include <google/cloud/functions/cloud_event.h>
+#include <google/cloud/functions/function.h>
 #include <boost/log/trivial.hpp>
 #include <nlohmann/json.hpp>
 
@@ -21,19 +21,21 @@ namespace gcf = ::google::cloud::functions;
 
 // Though not used in this example, the event is passed by value to support
 // applications that move-out its data.
-void hello_world_storage(gcf::CloudEvent event) {  // NOLINT
-  if (event.data_content_type().value_or("") != "application/json") {
-    BOOST_LOG_TRIVIAL(error) << "expected application/json data";
-    return;
-  }
-  auto const payload = nlohmann::json::parse(event.data().value_or("{}"));
-  BOOST_LOG_TRIVIAL(info) << "Event: " << event.id();
-  BOOST_LOG_TRIVIAL(info) << "Event Type: " << event.type();
-  BOOST_LOG_TRIVIAL(info) << "Bucket: " << payload.value("bucket", "");
-  BOOST_LOG_TRIVIAL(info) << "Object: " << payload.value("name", "");
-  BOOST_LOG_TRIVIAL(info) << "Metageneration: "
-                          << payload.value("metageneration", "");
-  BOOST_LOG_TRIVIAL(info) << "Created: " << payload.value("timeCreated", "");
-  BOOST_LOG_TRIVIAL(info) << "Updated: " << payload.value("updated", "");
+gcf::Function hello_world_storage() {
+  return gcf::MakeFunction([](gcf::CloudEvent const& event) {
+    if (event.data_content_type().value_or("") != "application/json") {
+      BOOST_LOG_TRIVIAL(error) << "expected application/json data";
+      return;
+    }
+    auto const payload = nlohmann::json::parse(event.data().value_or("{}"));
+    BOOST_LOG_TRIVIAL(info) << "Event: " << event.id();
+    BOOST_LOG_TRIVIAL(info) << "Event Type: " << event.type();
+    BOOST_LOG_TRIVIAL(info) << "Bucket: " << payload.value("bucket", "");
+    BOOST_LOG_TRIVIAL(info) << "Object: " << payload.value("name", "");
+    BOOST_LOG_TRIVIAL(info)
+        << "Metageneration: " << payload.value("metageneration", "");
+    BOOST_LOG_TRIVIAL(info) << "Created: " << payload.value("timeCreated", "");
+    BOOST_LOG_TRIVIAL(info) << "Updated: " << payload.value("updated", "");
+  });
 }
 // [END functions_helloworld_storage]

--- a/examples/site/howto_create_container/README.md
+++ b/examples/site/howto_create_container/README.md
@@ -30,25 +30,26 @@ In this guide we will be using this [function][snippet source]:
 <!-- inject-snippet-start -->
 [snippet source]: /examples/site/hello_world_http/hello_world_http.cc
 ```cc
-#include <google/cloud/functions/http_request.h>
-#include <google/cloud/functions/http_response.h>
+#include <google/cloud/functions/function.h>
 #include <nlohmann/json.hpp>
 
 namespace gcf = ::google::cloud::functions;
 
-gcf::HttpResponse hello_world_http(gcf::HttpRequest request) {
-  auto greeting = [r = std::move(request)] {
-    auto request_json = nlohmann::json::parse(r.payload(), /*cb=*/nullptr,
-                                              /*allow_exceptions=*/false);
-    if (request_json.count("name") && request_json["name"].is_string()) {
-      return "Hello " + request_json.value("name", "World") + "!";
-    }
-    return std::string("Hello World!");
-  };
+gcf::Function hello_world_http() {
+  return gcf::MakeFunction([](gcf::HttpRequest const& request) {
+    auto greeting = [r = std::move(request)] {
+      auto request_json = nlohmann::json::parse(r.payload(), /*cb=*/nullptr,
+                                                /*allow_exceptions=*/false);
+      if (request_json.count("name") && request_json["name"].is_string()) {
+        return "Hello " + request_json.value("name", "World") + "!";
+      }
+      return std::string("Hello World!");
+    };
 
-  return gcf::HttpResponse{}
-      .set_header("content-type", "text/plain")
-      .set_payload(greeting());
+    return gcf::HttpResponse{}
+        .set_header("content-type", "text/plain")
+        .set_payload(greeting());
+  });
 }
 ```
 <!-- inject-snippet-end -->

--- a/examples/site/howto_create_container/README.md
+++ b/examples/site/howto_create_container/README.md
@@ -85,7 +85,6 @@ containing your function:
 ```shell
 pack build \
     --builder gcr.io/buildpacks/builder:latest \
-    --env GOOGLE_FUNCTION_SIGNATURE_TYPE=http \
     --env GOOGLE_FUNCTION_TARGET=hello_world_http \
     --path examples/site/hello_world_http \
     gcf-cpp-hello-world-http

--- a/examples/site/howto_deploy_cloud_event/README.md
+++ b/examples/site/howto_deploy_cloud_event/README.md
@@ -33,22 +33,24 @@ In this guide we will be using this [function][snippet source]:
 <!-- inject-snippet-start -->
 [snippet source]: /examples/site/hello_world_pubsub/hello_world_pubsub.cc
 ```cc
-#include <google/cloud/functions/cloud_event.h>
+#include <google/cloud/functions/function.h>
 #include <boost/log/trivial.hpp>
 #include <cppcodec/base64_rfc4648.hpp>
 #include <nlohmann/json.hpp>
 
 namespace gcf = ::google::cloud::functions;
 
-void hello_world_pubsub(gcf::CloudEvent event) {
-  if (event.data_content_type().value_or("") != "application/json") {
-    BOOST_LOG_TRIVIAL(error) << "expected application/json data";
-    return;
-  }
-  auto const payload = nlohmann::json::parse(event.data().value_or("{}"));
-  auto const name = cppcodec::base64_rfc4648::decode<std::string>(
-      payload["message"]["data"].get<std::string>());
-  BOOST_LOG_TRIVIAL(info) << "Hello " << (name.empty() ? "World" : name);
+gcf::Function hello_world_pubsub() {
+  return gcf::MakeFunction([](gcf::CloudEvent const& event) {
+    if (event.data_content_type().value_or("") != "application/json") {
+      BOOST_LOG_TRIVIAL(error) << "expected application/json data";
+      return;
+    }
+    auto const payload = nlohmann::json::parse(event.data().value_or("{}"));
+    auto const name = cppcodec::base64_rfc4648::decode<std::string>(
+        payload["message"]["data"].get<std::string>());
+    BOOST_LOG_TRIVIAL(info) << "Hello " << (name.empty() ? "World" : name);
+  });
 }
 ```
 <!-- inject-snippet-end -->

--- a/examples/site/howto_deploy_cloud_event/README.md
+++ b/examples/site/howto_deploy_cloud_event/README.md
@@ -87,7 +87,6 @@ containing your function:
 GOOGLE_CLOUD_PROJECT=... # put the right value here
 pack build \
     --builder gcr.io/buildpacks/builder:latest \
-    --env GOOGLE_FUNCTION_SIGNATURE_TYPE=cloudevent \
     --env GOOGLE_FUNCTION_TARGET=hello_world_pubsub \
     --path examples/site/hello_world_pubsub \
    "gcr.io/${GOOGLE_CLOUD_PROJECT}/gcf-cpp-hello-world-pubsub"

--- a/examples/site/howto_deploy_to_cloud_run/README.md
+++ b/examples/site/howto_deploy_to_cloud_run/README.md
@@ -43,25 +43,26 @@ In this guide we will be using this [function][snippet source]:
 <!-- inject-snippet-start -->
 [snippet source]: /examples/site/hello_world_http/hello_world_http.cc
 ```cc
-#include <google/cloud/functions/http_request.h>
-#include <google/cloud/functions/http_response.h>
+#include <google/cloud/functions/function.h>
 #include <nlohmann/json.hpp>
 
 namespace gcf = ::google::cloud::functions;
 
-gcf::HttpResponse hello_world_http(gcf::HttpRequest request) {
-  auto greeting = [r = std::move(request)] {
-    auto request_json = nlohmann::json::parse(r.payload(), /*cb=*/nullptr,
-                                              /*allow_exceptions=*/false);
-    if (request_json.count("name") && request_json["name"].is_string()) {
-      return "Hello " + request_json.value("name", "World") + "!";
-    }
-    return std::string("Hello World!");
-  };
+gcf::Function hello_world_http() {
+  return gcf::MakeFunction([](gcf::HttpRequest const& request) {
+    auto greeting = [r = std::move(request)] {
+      auto request_json = nlohmann::json::parse(r.payload(), /*cb=*/nullptr,
+                                                /*allow_exceptions=*/false);
+      if (request_json.count("name") && request_json["name"].is_string()) {
+        return "Hello " + request_json.value("name", "World") + "!";
+      }
+      return std::string("Hello World!");
+    };
 
-  return gcf::HttpResponse{}
-      .set_header("content-type", "text/plain")
-      .set_payload(greeting());
+    return gcf::HttpResponse{}
+        .set_header("content-type", "text/plain")
+        .set_payload(greeting());
+  });
 }
 ```
 <!-- inject-snippet-end -->

--- a/examples/site/howto_deploy_to_cloud_run/README.md
+++ b/examples/site/howto_deploy_to_cloud_run/README.md
@@ -100,7 +100,6 @@ containing your function:
 GOOGLE_CLOUD_PROJECT=... # put the right value here
 pack build \
     --builder gcr.io/buildpacks/builder:latest \
-    --env GOOGLE_FUNCTION_SIGNATURE_TYPE=http \
     --env GOOGLE_FUNCTION_TARGET=hello_world_http \
     --path examples/site/hello_world_http \
    "gcr.io/${GOOGLE_CLOUD_PROJECT}/gcf-cpp-hello-world-http"

--- a/examples/site/howto_local_development/CMakeLists.txt
+++ b/examples/site/howto_local_development/CMakeLists.txt
@@ -18,7 +18,7 @@
 # CMake-based projects.
 
 cmake_minimum_required(VERSION 3.5)
-project(functions-framework-cpp-howto-local-development CXX C)
+project(functions-framework-cpp-howto-local-development CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/examples/site/howto_local_development/local_server.cc
+++ b/examples/site/howto_local_development/local_server.cc
@@ -19,14 +19,14 @@ namespace gcf = ::google::cloud::functions;
 
 namespace {
 
-gcf::HttpResponse HelloWithShutdown(gcf::HttpRequest const& /*request*/) {
-  return gcf::HttpResponse{}
-      .set_header("Content-Type", "text/plain")
-      .set_payload("Hello World\n");
+gcf::Function HelloLocal() {
+  return gcf::MakeFunction([](gcf::HttpRequest const& /*request*/) {
+    return gcf::HttpResponse{}
+        .set_header("Content-Type", "text/plain")
+        .set_payload("Hello World\n");
+  });
 }
 
 }  // namespace
 
-int main(int argc, char* argv[]) {
-  return ::google::cloud::functions::Run(argc, argv, HelloWithShutdown);
-}
+int main(int argc, char* argv[]) { return gcf::Run(argc, argv, HelloLocal()); }

--- a/examples/site/testing_http/http_integration_server.cc
+++ b/examples/site/testing_http/http_integration_server.cc
@@ -15,8 +15,8 @@
 #include <google/cloud/functions/framework.h>
 
 namespace gcf = ::google::cloud::functions;
-extern gcf::HttpResponse hello_world_http(gcf::HttpRequest request);
+extern gcf::Function hello_world_http();
 
 int main(int argc, char* argv[]) {
-  return gcf::Run(argc, argv, hello_world_http);
+  return gcf::Run(argc, argv, hello_world_http());
 }

--- a/examples/site/testing_http/http_unit_test.cc
+++ b/examples/site/testing_http/http_unit_test.cc
@@ -18,20 +18,20 @@
 #include <gtest/gtest.h>
 
 namespace gcf = ::google::cloud::functions;
-extern gcf::HttpResponse hello_world_http(gcf::HttpRequest request);
+extern gcf::HttpResponse hello_world_http_impl(gcf::HttpRequest request);
 
 namespace {
 
 TEST(HttpUnitTest, Success) {
-  auto actual = hello_world_http(
+  auto actual = hello_world_http_impl(
       gcf::HttpRequest{}.set_payload(R"js({ "name": "Foo" })js"));
   EXPECT_EQ(actual.payload(), "Hello Foo!");
 
-  actual = hello_world_http(
+  actual = hello_world_http_impl(
       gcf::HttpRequest{}.set_payload(R"js({ "unused": 7 })js"));
   EXPECT_EQ(actual.payload(), "Hello World!");
 
-  actual = hello_world_http(gcf::HttpRequest{}.set_payload("Bar"));
+  actual = hello_world_http_impl(gcf::HttpRequest{}.set_payload("Bar"));
   EXPECT_EQ(actual.payload(), "Hello World!");
 }
 

--- a/examples/site/testing_pubsub/README.md
+++ b/examples/site/testing_pubsub/README.md
@@ -12,22 +12,24 @@ We will use this [function][snippet source] throughput this guide:
 <!-- inject-snippet-start -->
 [snippet source]: /examples/site/hello_world_pubsub/hello_world_pubsub.cc
 ```cc
-#include <google/cloud/functions/cloud_event.h>
+#include <google/cloud/functions/function.h>
 #include <boost/log/trivial.hpp>
 #include <cppcodec/base64_rfc4648.hpp>
 #include <nlohmann/json.hpp>
 
 namespace gcf = ::google::cloud::functions;
 
-void hello_world_pubsub(gcf::CloudEvent event) {
-  if (event.data_content_type().value_or("") != "application/json") {
-    BOOST_LOG_TRIVIAL(error) << "expected application/json data";
-    return;
-  }
-  auto const payload = nlohmann::json::parse(event.data().value_or("{}"));
-  auto const name = cppcodec::base64_rfc4648::decode<std::string>(
-      payload["message"]["data"].get<std::string>());
-  BOOST_LOG_TRIVIAL(info) << "Hello " << (name.empty() ? "World" : name);
+gcf::Function hello_world_pubsub() {
+  return gcf::MakeFunction([](gcf::CloudEvent const& event) {
+    if (event.data_content_type().value_or("") != "application/json") {
+      BOOST_LOG_TRIVIAL(error) << "expected application/json data";
+      return;
+    }
+    auto const payload = nlohmann::json::parse(event.data().value_or("{}"));
+    auto const name = cppcodec::base64_rfc4648::decode<std::string>(
+        payload["message"]["data"].get<std::string>());
+    BOOST_LOG_TRIVIAL(info) << "Hello " << (name.empty() ? "World" : name);
+  });
 }
 ```
 <!-- inject-snippet-end -->

--- a/examples/site/testing_pubsub/pubsub_integration_server.cc
+++ b/examples/site/testing_pubsub/pubsub_integration_server.cc
@@ -15,8 +15,8 @@
 #include <google/cloud/functions/framework.h>
 
 namespace gcf = ::google::cloud::functions;
-extern void hello_world_pubsub(gcf::CloudEvent event);
+extern gcf::Function hello_world_pubsub();
 
 int main(int argc, char* argv[]) {
-  return gcf::Run(argc, argv, hello_world_pubsub);
+  return gcf::Run(argc, argv, hello_world_pubsub());
 }

--- a/examples/site/testing_pubsub/pubsub_unit_test.cc
+++ b/examples/site/testing_pubsub/pubsub_unit_test.cc
@@ -24,7 +24,7 @@
 #include <sstream>
 
 namespace gcf = ::google::cloud::functions;
-extern void hello_world_pubsub(gcf::CloudEvent event);
+extern void hello_world_pubsub_impl(gcf::CloudEvent const& event);
 
 namespace {
 
@@ -65,7 +65,7 @@ TEST(PubsubUnitTest, Basic) {
     event.set_data_content_type("application/json");
     event.set_data(test.data);
     stream->str({});
-    EXPECT_NO_THROW(hello_world_pubsub(event));
+    EXPECT_NO_THROW(hello_world_pubsub_impl(event));
     auto log_lines = stream->str();
     EXPECT_THAT(log_lines, HasSubstr(test.expected));
   }

--- a/examples/site/testing_storage/README.md
+++ b/examples/site/testing_storage/README.md
@@ -13,26 +13,28 @@ We will use this [function][snippet source] throughout this guide:
 <!-- inject-snippet-start -->
 [snippet source]: /examples/site/hello_world_storage/hello_world_storage.cc
 ```cc
-#include <google/cloud/functions/cloud_event.h>
+#include <google/cloud/functions/function.h>
 #include <boost/log/trivial.hpp>
 #include <nlohmann/json.hpp>
 
 namespace gcf = ::google::cloud::functions;
 
-void hello_world_storage(gcf::CloudEvent event) {
-  if (event.data_content_type().value_or("") != "application/json") {
-    BOOST_LOG_TRIVIAL(error) << "expected application/json data";
-    return;
-  }
-  auto const payload = nlohmann::json::parse(event.data().value_or("{}"));
-  BOOST_LOG_TRIVIAL(info) << "Event: " << event.id();
-  BOOST_LOG_TRIVIAL(info) << "Event Type: " << event.type();
-  BOOST_LOG_TRIVIAL(info) << "Bucket: " << payload.value("bucket", "");
-  BOOST_LOG_TRIVIAL(info) << "Object: " << payload.value("name", "");
-  BOOST_LOG_TRIVIAL(info) << "Metageneration: "
-                          << payload.value("metageneration", "");
-  BOOST_LOG_TRIVIAL(info) << "Created: " << payload.value("timeCreated", "");
-  BOOST_LOG_TRIVIAL(info) << "Updated: " << payload.value("updated", "");
+gcf::Function hello_world_storage() {
+  return gcf::MakeFunction([](gcf::CloudEvent const& event) {
+    if (event.data_content_type().value_or("") != "application/json") {
+      BOOST_LOG_TRIVIAL(error) << "expected application/json data";
+      return;
+    }
+    auto const payload = nlohmann::json::parse(event.data().value_or("{}"));
+    BOOST_LOG_TRIVIAL(info) << "Event: " << event.id();
+    BOOST_LOG_TRIVIAL(info) << "Event Type: " << event.type();
+    BOOST_LOG_TRIVIAL(info) << "Bucket: " << payload.value("bucket", "");
+    BOOST_LOG_TRIVIAL(info) << "Object: " << payload.value("name", "");
+    BOOST_LOG_TRIVIAL(info)
+        << "Metageneration: " << payload.value("metageneration", "");
+    BOOST_LOG_TRIVIAL(info) << "Created: " << payload.value("timeCreated", "");
+    BOOST_LOG_TRIVIAL(info) << "Updated: " << payload.value("updated", "");
+  });
 }
 ```
 <!-- inject-snippet-end -->

--- a/examples/site/testing_storage/storage_integration_server.cc
+++ b/examples/site/testing_storage/storage_integration_server.cc
@@ -15,8 +15,8 @@
 #include <google/cloud/functions/framework.h>
 
 namespace gcf = ::google::cloud::functions;
-extern void hello_world_storage(gcf::CloudEvent event);
+extern gcf::Function hello_world_storage();
 
 int main(int argc, char* argv[]) {
-  return gcf::Run(argc, argv, hello_world_storage);
+  return gcf::Run(argc, argv, hello_world_storage());
 }

--- a/examples/site/testing_storage/storage_unit_test.cc
+++ b/examples/site/testing_storage/storage_unit_test.cc
@@ -24,7 +24,7 @@
 #include <sstream>
 
 namespace gcf = ::google::cloud::functions;
-extern void hello_world_storage(gcf::CloudEvent event);
+extern void hello_world_storage_impl(gcf::CloudEvent const& event);
 
 namespace {
 
@@ -74,7 +74,7 @@ TEST(StorageUnitTest, Basic) {
     data["name"] = test.name;
     event.set_data(data.dump());
     stream->str({});
-    EXPECT_NO_THROW(hello_world_storage(event));
+    EXPECT_NO_THROW(hello_world_storage_impl(event));
     auto log_lines = stream->str();
     EXPECT_THAT(log_lines, HasSubstr(test.expected));
   }

--- a/examples/site_test.cc
+++ b/examples/site_test.cc
@@ -12,9 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/functions/internal/parse_cloud_event_json.h"
+#include "google/cloud/functions/internal/function_impl.h"
+#include "google/cloud/functions/internal/http_message_types.h"
 #include "google/cloud/functions/internal/setenv.h"
 #include "google/cloud/functions/cloud_event.h"
+#include "google/cloud/functions/function.h"
 #include "google/cloud/functions/http_request.h"
 #include "google/cloud/functions/http_response.h"
 #include <cppcodec/base64_rfc4648.hpp>
@@ -26,6 +28,8 @@
 #include <random>
 
 namespace gcf = ::google::cloud::functions;
+namespace gcf_internal = ::google::cloud::functions_internal;
+
 extern gcf::HttpResponse bearer_token(gcf::HttpRequest request);
 extern gcf::HttpResponse concepts_after_response(gcf::HttpRequest request);
 extern gcf::HttpResponse concepts_after_timeout(gcf::HttpRequest request);
@@ -35,9 +39,9 @@ extern gcf::HttpResponse concepts_stateless(gcf::HttpRequest request);
 extern gcf::HttpResponse env_vars(gcf::HttpRequest request);
 extern gcf::HttpResponse hello_world_error(gcf::HttpRequest request);
 extern gcf::HttpResponse hello_world_get(gcf::HttpRequest request);
-extern gcf::HttpResponse hello_world_http(gcf::HttpRequest request);
-extern void hello_world_pubsub(gcf::CloudEvent event);
-extern void hello_world_storage(gcf::CloudEvent event);
+extern gcf::Function hello_world_http();
+extern gcf::Function hello_world_pubsub();
+extern gcf::Function hello_world_storage();
 extern gcf::HttpResponse http_content(gcf::HttpRequest request);
 extern gcf::HttpResponse http_cors(gcf::HttpRequest request);
 extern gcf::HttpResponse http_cors_auth(gcf::HttpRequest request);
@@ -58,6 +62,18 @@ namespace {
 using ::testing::AllOf;
 using ::testing::HasSubstr;
 using ::testing::IsEmpty;
+
+auto TriggerFunctionHttp(gcf::Function const& function,
+                         gcf::HttpRequest const& r) {
+  gcf_internal::BeastRequest request;
+  request.target(r.target());
+  request.body() = r.payload();
+  for (auto const& [k, v] : r.headers()) request.insert(k, v);
+
+  auto handler =
+      gcf_internal::FunctionImpl::GetImpl(function)->GetHandler("unused");
+  return handler(std::move(request));
+}
 
 TEST(ExamplesSiteTest, BearerToken) {
   google::cloud::functions_internal::SetEnv("TARGET_URL", std::nullopt);
@@ -190,16 +206,17 @@ TEST(ExamplesSiteTest, HelloWorldGet) {
 }
 
 TEST(ExamplesSiteTest, HelloWorlHttp) {
-  auto actual = hello_world_http(
+  auto function = hello_world_http();
+  auto actual = TriggerFunctionHttp(function,
       gcf::HttpRequest{}.set_payload(R"js({ "name": "Foo" })js"));
-  EXPECT_EQ(actual.payload(), "Hello Foo!");
+  EXPECT_EQ(actual.body(), "Hello Foo!");
 
-  actual = hello_world_http(
+  actual = TriggerFunctionHttp(function,
       gcf::HttpRequest{}.set_payload(R"js({ "unused": 7 })js"));
-  EXPECT_EQ(actual.payload(), "Hello World!");
+  EXPECT_EQ(actual.body(), "Hello World!");
 
-  actual = hello_world_http(gcf::HttpRequest{}.set_payload("Bar"));
-  EXPECT_EQ(actual.payload(), "Hello World!");
+  actual = TriggerFunctionHttp(function, gcf::HttpRequest{}.set_payload("Bar"));
+  EXPECT_EQ(actual.body(), "Hello World!");
 }
 
 TEST(ExamplesSiteTest, HelloWorldPubSub) {


### PR DESCRIPTION
Change the How-to guides and associated examples to use declarative
configuration for the signature type.

Part of the work for #345