### PR TITLE
ci: site examples can be declarative

### DIFF
--- a/ci/generate-build-examples.sh
+++ b/ci/generate-build-examples.sh
@@ -113,6 +113,9 @@ site_example() {
   if grep -E -q 'gcf::CloudEvent|google::cloud::functions::CloudEvent' ${example}/*; then
     signature="cloudevent"
   fi
+  if grep -E -q 'gcf::Function|google::cloud::functions::Function' ${example}/*; then
+    signature="declarative"
+  fi
   local container="site-${function}"
 
   cat <<_EOF_


### PR DESCRIPTION
Part of the work for #345 

None of the site examples are declarative yet, but we will need this eventually.