### PR TITLE
doc: examples use declarative configuration 2/N

### DIFF
--- a/ci/build-examples.yaml
+++ b/ci/build-examples.yaml
@@ -234,7 +234,6 @@ steps:
     waitFor: ['gcf-builder-ready']
     id: 'site-hello_world_http'
     args: ['build',
-      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=http',
       '--env', 'GOOGLE_FUNCTION_TARGET=hello_world_http',
       '--path', 'examples/site/hello_world_http',
       'site-hello_world_http',
@@ -243,7 +242,6 @@ steps:
     waitFor: ['gcf-builder-ready']
     id: 'site-hello_world_pubsub'
     args: ['build',
-      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=cloudevent',
       '--env', 'GOOGLE_FUNCTION_TARGET=hello_world_pubsub',
       '--path', 'examples/site/hello_world_pubsub',
       'site-hello_world_pubsub',
@@ -252,7 +250,6 @@ steps:
     waitFor: ['gcf-builder-ready']
     id: 'site-hello_world_storage'
     args: ['build',
-      '--env', 'GOOGLE_FUNCTION_SIGNATURE_TYPE=cloudevent',
       '--env', 'GOOGLE_FUNCTION_TARGET=hello_world_storage',
       '--path', 'examples/site/hello_world_storage',
       'site-hello_world_storage',

--- a/ci/generate-build-examples.sh
+++ b/ci/generate-build-examples.sh
@@ -113,6 +113,9 @@ site_example() {
   if grep -E -q 'gcf::CloudEvent|google::cloud::functions::CloudEvent' ${example}/*; then
     signature="cloudevent"
   fi
+  if grep -E -q 'gcf::Function|google::cloud::functions::Function' ${example}/*; then
+    signature="declarative"
+  fi
   local container="site-${function}"
 
   cat <<_EOF_

--- a/examples/site/hello_world_http/hello_world_http.cc
+++ b/examples/site/hello_world_http/hello_world_http.cc
@@ -13,13 +13,12 @@
 // limitations under the License.
 
 // [START functions_helloworld_http]
-#include <google/cloud/functions/http_request.h>
-#include <google/cloud/functions/http_response.h>
+#include <google/cloud/functions/function.h>
 #include <nlohmann/json.hpp>
 
 namespace gcf = ::google::cloud::functions;
 
-gcf::HttpResponse hello_world_http(gcf::HttpRequest request) {
+gcf::HttpResponse hello_world_http_impl(gcf::HttpRequest request) {
   auto greeting = [r = std::move(request)] {
     auto request_json = nlohmann::json::parse(r.payload(), /*cb=*/nullptr,
                                               /*allow_exceptions=*/false);
@@ -32,5 +31,9 @@ gcf::HttpResponse hello_world_http(gcf::HttpRequest request) {
   return gcf::HttpResponse{}
       .set_header("content-type", "text/plain")
       .set_payload(greeting());
+}
+
+gcf::Function hello_world_http() {
+  return gcf::MakeFunction(hello_world_http_impl);
 }
 // [END functions_helloworld_http]

--- a/examples/site/hello_world_pubsub/hello_world_pubsub.cc
+++ b/examples/site/hello_world_pubsub/hello_world_pubsub.cc
@@ -13,16 +13,14 @@
 // limitations under the License.
 
 // [START functions_helloworld_pubsub]
-#include <google/cloud/functions/cloud_event.h>
+#include <google/cloud/functions/function.h>
 #include <boost/log/trivial.hpp>
 #include <cppcodec/base64_rfc4648.hpp>
 #include <nlohmann/json.hpp>
 
 namespace gcf = ::google::cloud::functions;
 
-// Though not used in this example, the event is passed by value to support
-// applications that move-out its data.
-void hello_world_pubsub(gcf::CloudEvent event) {  // NOLINT
+void hello_world_pubsub_impl(gcf::CloudEvent const& event) {
   if (event.data_content_type().value_or("") != "application/json") {
     BOOST_LOG_TRIVIAL(error) << "expected application/json data";
     return;
@@ -31,5 +29,9 @@ void hello_world_pubsub(gcf::CloudEvent event) {  // NOLINT
   auto const name = cppcodec::base64_rfc4648::decode<std::string>(
       payload["message"]["data"].get<std::string>());
   BOOST_LOG_TRIVIAL(info) << "Hello " << (name.empty() ? "World" : name);
+}
+
+gcf::Function hello_world_pubsub() {
+  return gcf::MakeFunction(hello_world_pubsub_impl);
 }
 // [END functions_helloworld_pubsub]

--- a/examples/site/hello_world_storage/hello_world_storage.cc
+++ b/examples/site/hello_world_storage/hello_world_storage.cc
@@ -13,15 +13,13 @@
 // limitations under the License.
 
 // [START functions_helloworld_storage]
-#include <google/cloud/functions/cloud_event.h>
+#include <google/cloud/functions/function.h>
 #include <boost/log/trivial.hpp>
 #include <nlohmann/json.hpp>
 
 namespace gcf = ::google::cloud::functions;
 
-// Though not used in this example, the event is passed by value to support
-// applications that move-out its data.
-void hello_world_storage(gcf::CloudEvent event) {  // NOLINT
+void hello_world_storage_impl(gcf::CloudEvent const& event) {
   if (event.data_content_type().value_or("") != "application/json") {
     BOOST_LOG_TRIVIAL(error) << "expected application/json data";
     return;
@@ -35,5 +33,9 @@ void hello_world_storage(gcf::CloudEvent event) {  // NOLINT
                           << payload.value("metageneration", "");
   BOOST_LOG_TRIVIAL(info) << "Created: " << payload.value("timeCreated", "");
   BOOST_LOG_TRIVIAL(info) << "Updated: " << payload.value("updated", "");
+}
+
+gcf::Function hello_world_storage() {
+  return gcf::MakeFunction(hello_world_storage_impl);
 }
 // [END functions_helloworld_storage]

--- a/examples/site/howto_create_container/README.md
+++ b/examples/site/howto_create_container/README.md
@@ -35,21 +35,23 @@ In this guide we will be using this [function][snippet source]:
 
 namespace gcf = ::google::cloud::functions;
 
-gcf::Function hello_world_http() {
-  return gcf::MakeFunction([](gcf::HttpRequest const& request) {
-    auto greeting = [r = std::move(request)] {
-      auto request_json = nlohmann::json::parse(r.payload(), /*cb=*/nullptr,
-                                                /*allow_exceptions=*/false);
-      if (request_json.count("name") && request_json["name"].is_string()) {
-        return "Hello " + request_json.value("name", "World") + "!";
-      }
-      return std::string("Hello World!");
-    };
+gcf::HttpResponse hello_world_http_impl(gcf::HttpRequest request) {
+  auto greeting = [r = std::move(request)] {
+    auto request_json = nlohmann::json::parse(r.payload(), /*cb=*/nullptr,
+                                              /*allow_exceptions=*/false);
+    if (request_json.count("name") && request_json["name"].is_string()) {
+      return "Hello " + request_json.value("name", "World") + "!";
+    }
+    return std::string("Hello World!");
+  };
 
-    return gcf::HttpResponse{}
-        .set_header("content-type", "text/plain")
-        .set_payload(greeting());
-  });
+  return gcf::HttpResponse{}
+      .set_header("content-type", "text/plain")
+      .set_payload(greeting());
+}
+
+gcf::Function hello_world_http() {
+  return gcf::MakeFunction(hello_world_http_impl);
 }
 ```
 <!-- inject-snippet-end -->

--- a/examples/site/howto_create_container/README.md
+++ b/examples/site/howto_create_container/README.md
@@ -30,25 +30,26 @@ In this guide we will be using this [function][snippet source]:
 <!-- inject-snippet-start -->
 [snippet source]: /examples/site/hello_world_http/hello_world_http.cc
 ```cc
-#include <google/cloud/functions/http_request.h>
-#include <google/cloud/functions/http_response.h>
+#include <google/cloud/functions/function.h>
 #include <nlohmann/json.hpp>
 
 namespace gcf = ::google::cloud::functions;
 
-gcf::HttpResponse hello_world_http(gcf::HttpRequest request) {
-  auto greeting = [r = std::move(request)] {
-    auto request_json = nlohmann::json::parse(r.payload(), /*cb=*/nullptr,
-                                              /*allow_exceptions=*/false);
-    if (request_json.count("name") && request_json["name"].is_string()) {
-      return "Hello " + request_json.value("name", "World") + "!";
-    }
-    return std::string("Hello World!");
-  };
+gcf::Function hello_world_http() {
+  return gcf::MakeFunction([](gcf::HttpRequest const& request) {
+    auto greeting = [r = std::move(request)] {
+      auto request_json = nlohmann::json::parse(r.payload(), /*cb=*/nullptr,
+                                                /*allow_exceptions=*/false);
+      if (request_json.count("name") && request_json["name"].is_string()) {
+        return "Hello " + request_json.value("name", "World") + "!";
+      }
+      return std::string("Hello World!");
+    };
 
-  return gcf::HttpResponse{}
-      .set_header("content-type", "text/plain")
-      .set_payload(greeting());
+    return gcf::HttpResponse{}
+        .set_header("content-type", "text/plain")
+        .set_payload(greeting());
+  });
 }
 ```
 <!-- inject-snippet-end -->
@@ -85,7 +86,6 @@ containing your function:
 ```shell
 pack build \
     --builder gcr.io/buildpacks/builder:latest \
-    --env GOOGLE_FUNCTION_SIGNATURE_TYPE=http \
     --env GOOGLE_FUNCTION_TARGET=hello_world_http \
     --path examples/site/hello_world_http \
     gcf-cpp-hello-world-http

--- a/examples/site/howto_deploy_cloud_event/README.md
+++ b/examples/site/howto_deploy_cloud_event/README.md
@@ -40,17 +40,19 @@ In this guide we will be using this [function][snippet source]:
 
 namespace gcf = ::google::cloud::functions;
 
+void hello_world_pubsub_impl(gcf::CloudEvent const& event) {
+  if (event.data_content_type().value_or("") != "application/json") {
+    BOOST_LOG_TRIVIAL(error) << "expected application/json data";
+    return;
+  }
+  auto const payload = nlohmann::json::parse(event.data().value_or("{}"));
+  auto const name = cppcodec::base64_rfc4648::decode<std::string>(
+      payload["message"]["data"].get<std::string>());
+  BOOST_LOG_TRIVIAL(info) << "Hello " << (name.empty() ? "World" : name);
+}
+
 gcf::Function hello_world_pubsub() {
-  return gcf::MakeFunction([](gcf::CloudEvent const& event) {
-    if (event.data_content_type().value_or("") != "application/json") {
-      BOOST_LOG_TRIVIAL(error) << "expected application/json data";
-      return;
-    }
-    auto const payload = nlohmann::json::parse(event.data().value_or("{}"));
-    auto const name = cppcodec::base64_rfc4648::decode<std::string>(
-        payload["message"]["data"].get<std::string>());
-    BOOST_LOG_TRIVIAL(info) << "Hello " << (name.empty() ? "World" : name);
-  });
+  return gcf::MakeFunction(hello_world_pubsub_impl);
 }
 ```
 <!-- inject-snippet-end -->

--- a/examples/site/howto_deploy_cloud_event/README.md
+++ b/examples/site/howto_deploy_cloud_event/README.md
@@ -33,22 +33,24 @@ In this guide we will be using this [function][snippet source]:
 <!-- inject-snippet-start -->
 [snippet source]: /examples/site/hello_world_pubsub/hello_world_pubsub.cc
 ```cc
-#include <google/cloud/functions/cloud_event.h>
+#include <google/cloud/functions/function.h>
 #include <boost/log/trivial.hpp>
 #include <cppcodec/base64_rfc4648.hpp>
 #include <nlohmann/json.hpp>
 
 namespace gcf = ::google::cloud::functions;
 
-void hello_world_pubsub(gcf::CloudEvent event) {
-  if (event.data_content_type().value_or("") != "application/json") {
-    BOOST_LOG_TRIVIAL(error) << "expected application/json data";
-    return;
-  }
-  auto const payload = nlohmann::json::parse(event.data().value_or("{}"));
-  auto const name = cppcodec::base64_rfc4648::decode<std::string>(
-      payload["message"]["data"].get<std::string>());
-  BOOST_LOG_TRIVIAL(info) << "Hello " << (name.empty() ? "World" : name);
+gcf::Function hello_world_pubsub() {
+  return gcf::MakeFunction([](gcf::CloudEvent const& event) {
+    if (event.data_content_type().value_or("") != "application/json") {
+      BOOST_LOG_TRIVIAL(error) << "expected application/json data";
+      return;
+    }
+    auto const payload = nlohmann::json::parse(event.data().value_or("{}"));
+    auto const name = cppcodec::base64_rfc4648::decode<std::string>(
+        payload["message"]["data"].get<std::string>());
+    BOOST_LOG_TRIVIAL(info) << "Hello " << (name.empty() ? "World" : name);
+  });
 }
 ```
 <!-- inject-snippet-end -->
@@ -87,7 +89,6 @@ containing your function:
 GOOGLE_CLOUD_PROJECT=... # put the right value here
 pack build \
     --builder gcr.io/buildpacks/builder:latest \
-    --env GOOGLE_FUNCTION_SIGNATURE_TYPE=cloudevent \
     --env GOOGLE_FUNCTION_TARGET=hello_world_pubsub \
     --path examples/site/hello_world_pubsub \
    "gcr.io/${GOOGLE_CLOUD_PROJECT}/gcf-cpp-hello-world-pubsub"

--- a/examples/site/howto_deploy_to_cloud_run/README.md
+++ b/examples/site/howto_deploy_to_cloud_run/README.md
@@ -48,21 +48,23 @@ In this guide we will be using this [function][snippet source]:
 
 namespace gcf = ::google::cloud::functions;
 
-gcf::Function hello_world_http() {
-  return gcf::MakeFunction([](gcf::HttpRequest const& request) {
-    auto greeting = [r = std::move(request)] {
-      auto request_json = nlohmann::json::parse(r.payload(), /*cb=*/nullptr,
-                                                /*allow_exceptions=*/false);
-      if (request_json.count("name") && request_json["name"].is_string()) {
-        return "Hello " + request_json.value("name", "World") + "!";
-      }
-      return std::string("Hello World!");
-    };
+gcf::HttpResponse hello_world_http_impl(gcf::HttpRequest request) {
+  auto greeting = [r = std::move(request)] {
+    auto request_json = nlohmann::json::parse(r.payload(), /*cb=*/nullptr,
+                                              /*allow_exceptions=*/false);
+    if (request_json.count("name") && request_json["name"].is_string()) {
+      return "Hello " + request_json.value("name", "World") + "!";
+    }
+    return std::string("Hello World!");
+  };
 
-    return gcf::HttpResponse{}
-        .set_header("content-type", "text/plain")
-        .set_payload(greeting());
-  });
+  return gcf::HttpResponse{}
+      .set_header("content-type", "text/plain")
+      .set_payload(greeting());
+}
+
+gcf::Function hello_world_http() {
+  return gcf::MakeFunction(hello_world_http_impl);
 }
 ```
 <!-- inject-snippet-end -->

--- a/examples/site/howto_deploy_to_cloud_run/README.md
+++ b/examples/site/howto_deploy_to_cloud_run/README.md
@@ -43,25 +43,26 @@ In this guide we will be using this [function][snippet source]:
 <!-- inject-snippet-start -->
 [snippet source]: /examples/site/hello_world_http/hello_world_http.cc
 ```cc
-#include <google/cloud/functions/http_request.h>
-#include <google/cloud/functions/http_response.h>
+#include <google/cloud/functions/function.h>
 #include <nlohmann/json.hpp>
 
 namespace gcf = ::google::cloud::functions;
 
-gcf::HttpResponse hello_world_http(gcf::HttpRequest request) {
-  auto greeting = [r = std::move(request)] {
-    auto request_json = nlohmann::json::parse(r.payload(), /*cb=*/nullptr,
-                                              /*allow_exceptions=*/false);
-    if (request_json.count("name") && request_json["name"].is_string()) {
-      return "Hello " + request_json.value("name", "World") + "!";
-    }
-    return std::string("Hello World!");
-  };
+gcf::Function hello_world_http() {
+  return gcf::MakeFunction([](gcf::HttpRequest const& request) {
+    auto greeting = [r = std::move(request)] {
+      auto request_json = nlohmann::json::parse(r.payload(), /*cb=*/nullptr,
+                                                /*allow_exceptions=*/false);
+      if (request_json.count("name") && request_json["name"].is_string()) {
+        return "Hello " + request_json.value("name", "World") + "!";
+      }
+      return std::string("Hello World!");
+    };
 
-  return gcf::HttpResponse{}
-      .set_header("content-type", "text/plain")
-      .set_payload(greeting());
+    return gcf::HttpResponse{}
+        .set_header("content-type", "text/plain")
+        .set_payload(greeting());
+  });
 }
 ```
 <!-- inject-snippet-end -->
@@ -100,7 +101,6 @@ containing your function:
 GOOGLE_CLOUD_PROJECT=... # put the right value here
 pack build \
     --builder gcr.io/buildpacks/builder:latest \
-    --env GOOGLE_FUNCTION_SIGNATURE_TYPE=http \
     --env GOOGLE_FUNCTION_TARGET=hello_world_http \
     --path examples/site/hello_world_http \
    "gcr.io/${GOOGLE_CLOUD_PROJECT}/gcf-cpp-hello-world-http"

--- a/examples/site/howto_local_development/CMakeLists.txt
+++ b/examples/site/howto_local_development/CMakeLists.txt
@@ -18,7 +18,7 @@
 # CMake-based projects.
 
 cmake_minimum_required(VERSION 3.5)
-project(functions-framework-cpp-howto-local-development CXX C)
+project(functions-framework-cpp-howto-local-development CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/examples/site/howto_local_development/local_server.cc
+++ b/examples/site/howto_local_development/local_server.cc
@@ -19,14 +19,14 @@ namespace gcf = ::google::cloud::functions;
 
 namespace {
 
-gcf::HttpResponse HelloWithShutdown(gcf::HttpRequest const& /*request*/) {
-  return gcf::HttpResponse{}
-      .set_header("Content-Type", "text/plain")
-      .set_payload("Hello World\n");
+gcf::Function HelloLocal() {
+  return gcf::MakeFunction([](gcf::HttpRequest const& /*request*/) {
+    return gcf::HttpResponse{}
+        .set_header("Content-Type", "text/plain")
+        .set_payload("Hello World\n");
+  });
 }
 
 }  // namespace
 
-int main(int argc, char* argv[]) {
-  return ::google::cloud::functions::Run(argc, argv, HelloWithShutdown);
-}
+int main(int argc, char* argv[]) { return gcf::Run(argc, argv, HelloLocal()); }

--- a/examples/site/testing_http/http_integration_server.cc
+++ b/examples/site/testing_http/http_integration_server.cc
@@ -15,8 +15,8 @@
 #include <google/cloud/functions/framework.h>
 
 namespace gcf = ::google::cloud::functions;
-extern gcf::HttpResponse hello_world_http(gcf::HttpRequest request);
+extern gcf::Function hello_world_http();
 
 int main(int argc, char* argv[]) {
-  return gcf::Run(argc, argv, hello_world_http);
+  return gcf::Run(argc, argv, hello_world_http());
 }

--- a/examples/site/testing_http/http_unit_test.cc
+++ b/examples/site/testing_http/http_unit_test.cc
@@ -18,20 +18,20 @@
 #include <gtest/gtest.h>
 
 namespace gcf = ::google::cloud::functions;
-extern gcf::HttpResponse hello_world_http(gcf::HttpRequest request);
+extern gcf::HttpResponse hello_world_http_impl(gcf::HttpRequest request);
 
 namespace {
 
 TEST(HttpUnitTest, Success) {
-  auto actual = hello_world_http(
+  auto actual = hello_world_http_impl(
       gcf::HttpRequest{}.set_payload(R"js({ "name": "Foo" })js"));
   EXPECT_EQ(actual.payload(), "Hello Foo!");
 
-  actual = hello_world_http(
+  actual = hello_world_http_impl(
       gcf::HttpRequest{}.set_payload(R"js({ "unused": 7 })js"));
   EXPECT_EQ(actual.payload(), "Hello World!");
 
-  actual = hello_world_http(gcf::HttpRequest{}.set_payload("Bar"));
+  actual = hello_world_http_impl(gcf::HttpRequest{}.set_payload("Bar"));
   EXPECT_EQ(actual.payload(), "Hello World!");
 }
 

--- a/examples/site/testing_pubsub/README.md
+++ b/examples/site/testing_pubsub/README.md
@@ -19,17 +19,19 @@ We will use this [function][snippet source] throughput this guide:
 
 namespace gcf = ::google::cloud::functions;
 
+void hello_world_pubsub_impl(gcf::CloudEvent const& event) {
+  if (event.data_content_type().value_or("") != "application/json") {
+    BOOST_LOG_TRIVIAL(error) << "expected application/json data";
+    return;
+  }
+  auto const payload = nlohmann::json::parse(event.data().value_or("{}"));
+  auto const name = cppcodec::base64_rfc4648::decode<std::string>(
+      payload["message"]["data"].get<std::string>());
+  BOOST_LOG_TRIVIAL(info) << "Hello " << (name.empty() ? "World" : name);
+}
+
 gcf::Function hello_world_pubsub() {
-  return gcf::MakeFunction([](gcf::CloudEvent const& event) {
-    if (event.data_content_type().value_or("") != "application/json") {
-      BOOST_LOG_TRIVIAL(error) << "expected application/json data";
-      return;
-    }
-    auto const payload = nlohmann::json::parse(event.data().value_or("{}"));
-    auto const name = cppcodec::base64_rfc4648::decode<std::string>(
-        payload["message"]["data"].get<std::string>());
-    BOOST_LOG_TRIVIAL(info) << "Hello " << (name.empty() ? "World" : name);
-  });
+  return gcf::MakeFunction(hello_world_pubsub_impl);
 }
 ```
 <!-- inject-snippet-end -->

--- a/examples/site/testing_pubsub/README.md
+++ b/examples/site/testing_pubsub/README.md
@@ -12,22 +12,24 @@ We will use this [function][snippet source] throughput this guide:
 <!-- inject-snippet-start -->
 [snippet source]: /examples/site/hello_world_pubsub/hello_world_pubsub.cc
 ```cc
-#include <google/cloud/functions/cloud_event.h>
+#include <google/cloud/functions/function.h>
 #include <boost/log/trivial.hpp>
 #include <cppcodec/base64_rfc4648.hpp>
 #include <nlohmann/json.hpp>
 
 namespace gcf = ::google::cloud::functions;
 
-void hello_world_pubsub(gcf::CloudEvent event) {
-  if (event.data_content_type().value_or("") != "application/json") {
-    BOOST_LOG_TRIVIAL(error) << "expected application/json data";
-    return;
-  }
-  auto const payload = nlohmann::json::parse(event.data().value_or("{}"));
-  auto const name = cppcodec::base64_rfc4648::decode<std::string>(
-      payload["message"]["data"].get<std::string>());
-  BOOST_LOG_TRIVIAL(info) << "Hello " << (name.empty() ? "World" : name);
+gcf::Function hello_world_pubsub() {
+  return gcf::MakeFunction([](gcf::CloudEvent const& event) {
+    if (event.data_content_type().value_or("") != "application/json") {
+      BOOST_LOG_TRIVIAL(error) << "expected application/json data";
+      return;
+    }
+    auto const payload = nlohmann::json::parse(event.data().value_or("{}"));
+    auto const name = cppcodec::base64_rfc4648::decode<std::string>(
+        payload["message"]["data"].get<std::string>());
+    BOOST_LOG_TRIVIAL(info) << "Hello " << (name.empty() ? "World" : name);
+  });
 }
 ```
 <!-- inject-snippet-end -->

--- a/examples/site/testing_pubsub/pubsub_integration_server.cc
+++ b/examples/site/testing_pubsub/pubsub_integration_server.cc
@@ -15,8 +15,8 @@
 #include <google/cloud/functions/framework.h>
 
 namespace gcf = ::google::cloud::functions;
-extern void hello_world_pubsub(gcf::CloudEvent event);
+extern gcf::Function hello_world_pubsub();
 
 int main(int argc, char* argv[]) {
-  return gcf::Run(argc, argv, hello_world_pubsub);
+  return gcf::Run(argc, argv, hello_world_pubsub());
 }

--- a/examples/site/testing_pubsub/pubsub_unit_test.cc
+++ b/examples/site/testing_pubsub/pubsub_unit_test.cc
@@ -24,7 +24,7 @@
 #include <sstream>
 
 namespace gcf = ::google::cloud::functions;
-extern void hello_world_pubsub(gcf::CloudEvent event);
+extern void hello_world_pubsub_impl(gcf::CloudEvent const& event);
 
 namespace {
 
@@ -65,7 +65,7 @@ TEST(PubsubUnitTest, Basic) {
     event.set_data_content_type("application/json");
     event.set_data(test.data);
     stream->str({});
-    EXPECT_NO_THROW(hello_world_pubsub(event));
+    EXPECT_NO_THROW(hello_world_pubsub_impl(event));
     auto log_lines = stream->str();
     EXPECT_THAT(log_lines, HasSubstr(test.expected));
   }

--- a/examples/site/testing_storage/README.md
+++ b/examples/site/testing_storage/README.md
@@ -19,22 +19,24 @@ We will use this [function][snippet source] throughout this guide:
 
 namespace gcf = ::google::cloud::functions;
 
+void hello_world_storage_impl(gcf::CloudEvent const& event) {
+  if (event.data_content_type().value_or("") != "application/json") {
+    BOOST_LOG_TRIVIAL(error) << "expected application/json data";
+    return;
+  }
+  auto const payload = nlohmann::json::parse(event.data().value_or("{}"));
+  BOOST_LOG_TRIVIAL(info) << "Event: " << event.id();
+  BOOST_LOG_TRIVIAL(info) << "Event Type: " << event.type();
+  BOOST_LOG_TRIVIAL(info) << "Bucket: " << payload.value("bucket", "");
+  BOOST_LOG_TRIVIAL(info) << "Object: " << payload.value("name", "");
+  BOOST_LOG_TRIVIAL(info) << "Metageneration: "
+                          << payload.value("metageneration", "");
+  BOOST_LOG_TRIVIAL(info) << "Created: " << payload.value("timeCreated", "");
+  BOOST_LOG_TRIVIAL(info) << "Updated: " << payload.value("updated", "");
+}
+
 gcf::Function hello_world_storage() {
-  return gcf::MakeFunction([](gcf::CloudEvent const& event) {
-    if (event.data_content_type().value_or("") != "application/json") {
-      BOOST_LOG_TRIVIAL(error) << "expected application/json data";
-      return;
-    }
-    auto const payload = nlohmann::json::parse(event.data().value_or("{}"));
-    BOOST_LOG_TRIVIAL(info) << "Event: " << event.id();
-    BOOST_LOG_TRIVIAL(info) << "Event Type: " << event.type();
-    BOOST_LOG_TRIVIAL(info) << "Bucket: " << payload.value("bucket", "");
-    BOOST_LOG_TRIVIAL(info) << "Object: " << payload.value("name", "");
-    BOOST_LOG_TRIVIAL(info)
-        << "Metageneration: " << payload.value("metageneration", "");
-    BOOST_LOG_TRIVIAL(info) << "Created: " << payload.value("timeCreated", "");
-    BOOST_LOG_TRIVIAL(info) << "Updated: " << payload.value("updated", "");
-  });
+  return gcf::MakeFunction(hello_world_storage_impl);
 }
 ```
 <!-- inject-snippet-end -->

--- a/examples/site/testing_storage/README.md
+++ b/examples/site/testing_storage/README.md
@@ -13,26 +13,28 @@ We will use this [function][snippet source] throughout this guide:
 <!-- inject-snippet-start -->
 [snippet source]: /examples/site/hello_world_storage/hello_world_storage.cc
 ```cc
-#include <google/cloud/functions/cloud_event.h>
+#include <google/cloud/functions/function.h>
 #include <boost/log/trivial.hpp>
 #include <nlohmann/json.hpp>
 
 namespace gcf = ::google::cloud::functions;
 
-void hello_world_storage(gcf::CloudEvent event) {
-  if (event.data_content_type().value_or("") != "application/json") {
-    BOOST_LOG_TRIVIAL(error) << "expected application/json data";
-    return;
-  }
-  auto const payload = nlohmann::json::parse(event.data().value_or("{}"));
-  BOOST_LOG_TRIVIAL(info) << "Event: " << event.id();
-  BOOST_LOG_TRIVIAL(info) << "Event Type: " << event.type();
-  BOOST_LOG_TRIVIAL(info) << "Bucket: " << payload.value("bucket", "");
-  BOOST_LOG_TRIVIAL(info) << "Object: " << payload.value("name", "");
-  BOOST_LOG_TRIVIAL(info) << "Metageneration: "
-                          << payload.value("metageneration", "");
-  BOOST_LOG_TRIVIAL(info) << "Created: " << payload.value("timeCreated", "");
-  BOOST_LOG_TRIVIAL(info) << "Updated: " << payload.value("updated", "");
+gcf::Function hello_world_storage() {
+  return gcf::MakeFunction([](gcf::CloudEvent const& event) {
+    if (event.data_content_type().value_or("") != "application/json") {
+      BOOST_LOG_TRIVIAL(error) << "expected application/json data";
+      return;
+    }
+    auto const payload = nlohmann::json::parse(event.data().value_or("{}"));
+    BOOST_LOG_TRIVIAL(info) << "Event: " << event.id();
+    BOOST_LOG_TRIVIAL(info) << "Event Type: " << event.type();
+    BOOST_LOG_TRIVIAL(info) << "Bucket: " << payload.value("bucket", "");
+    BOOST_LOG_TRIVIAL(info) << "Object: " << payload.value("name", "");
+    BOOST_LOG_TRIVIAL(info)
+        << "Metageneration: " << payload.value("metageneration", "");
+    BOOST_LOG_TRIVIAL(info) << "Created: " << payload.value("timeCreated", "");
+    BOOST_LOG_TRIVIAL(info) << "Updated: " << payload.value("updated", "");
+  });
 }
 ```
 <!-- inject-snippet-end -->

--- a/examples/site/testing_storage/storage_integration_server.cc
+++ b/examples/site/testing_storage/storage_integration_server.cc
@@ -15,8 +15,8 @@
 #include <google/cloud/functions/framework.h>
 
 namespace gcf = ::google::cloud::functions;
-extern void hello_world_storage(gcf::CloudEvent event);
+extern gcf::Function hello_world_storage();
 
 int main(int argc, char* argv[]) {
-  return gcf::Run(argc, argv, hello_world_storage);
+  return gcf::Run(argc, argv, hello_world_storage());
 }

--- a/examples/site/testing_storage/storage_unit_test.cc
+++ b/examples/site/testing_storage/storage_unit_test.cc
@@ -24,7 +24,7 @@
 #include <sstream>
 
 namespace gcf = ::google::cloud::functions;
-extern void hello_world_storage(gcf::CloudEvent event);
+extern void hello_world_storage_impl(gcf::CloudEvent const& event);
 
 namespace {
 
@@ -74,7 +74,7 @@ TEST(StorageUnitTest, Basic) {
     data["name"] = test.name;
     event.set_data(data.dump());
     stream->str({});
-    EXPECT_NO_THROW(hello_world_storage(event));
+    EXPECT_NO_THROW(hello_world_storage_impl(event));
     auto log_lines = stream->str();
     EXPECT_THAT(log_lines, HasSubstr(test.expected));
   }


### PR DESCRIPTION
Change the How-to guides and associated examples to use declarative configuration for the signature type.