### PR TITLE
ci: use `allowFailure` for optional steps

### DIFF
--- a/ci/build-examples.yaml
+++ b/ci/build-examples.yaml
@@ -426,6 +426,7 @@ steps:
 
   # Remove the images created by this build.
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    allowFailure: true
     entrypoint: 'bash'
     args:
       - '-c'
@@ -434,13 +435,13 @@ steps:
         gcloud container images delete -q gcr.io/${PROJECT_ID}/ci/run-image:${BUILD_ID}
         gcloud container images delete -q gcr.io/${PROJECT_ID}/ci/build-image:${BUILD_ID}
         gcloud container images delete -q gcr.io/${PROJECT_ID}/ci/hello-world:${BUILD_ID}
-        exit 0
 
   # The previous step may not run if the build fails. Garbage collect any
   # images created by this script more than 4 weeks ago. This step should
   # not break the build on error, and it can start running as soon as the
   # build does.
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    allowFailure: true
     waitFor: ['-']
     entrypoint: 'bash'
     args:
@@ -453,4 +454,3 @@ steps:
           xargs printf "gcr.io/${PROJECT_ID}/$${image}@$$1\n"
         done | \
         xargs -P 4 -L 32 gcloud container images delete -q --force-delete-tags
-        exit 0

--- a/ci/cloudbuild/cloudbuild.yaml
+++ b/ci/cloudbuild/cloudbuild.yaml
@@ -63,9 +63,9 @@ steps:
     entrypoint: '/bin/true'
 
   # Restores the homedir cache into /h in parallel with the previous step.
-  # Won't break the build if this step fails.
   - name: 'gcr.io/cloud-builders/gsutil'
     waitFor: [ '-' ]
+    allowFailure: true
     entrypoint: 'bash'
     dir: '/h'
     args:
@@ -75,17 +75,16 @@ steps:
         --bucket_url=gs://${_CACHE_BUCKET}/build-cache/functions-framework-cpp
         --key=${_TRIGGER_SOURCE}/${_DISTRO}-${_BUILD_NAME}/h
         --fallback_key=main/${_DISTRO}-${_BUILD_NAME}/h
-        || true
 
   # Remove the images created by this build.
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    allowFailure: true
     entrypoint: 'bash'
     args:
       - '-c'
       - |
         set +e
         gcloud container images delete -q gcr.io/${PROJECT_ID}/${_IMAGE}:${BUILD_ID}
-        exit 0
 
     # The previous step may not run if the build fails. Garbage collect any
     # images created by this script, and/or similar scripts in this repository.
@@ -95,6 +94,7 @@ steps:
     # can start running as soon as the build does.
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     waitFor: [ '-' ]
+    alloFailure: true
     entrypoint: 'bash'
     args:
       - '-c'
@@ -104,4 +104,3 @@ steps:
           --format='get(digest)' --filter='timestamp.datetime < -P4W' | \
           xargs -r printf "gcr.io/${PROJECT_ID}/${_IMAGE}@%s\n" | \
           xargs -r -P 4 -L 32 gcloud container images delete -q --force-delete-tags
-        exit 0

--- a/ci/cloudbuild/cloudbuild.yaml
+++ b/ci/cloudbuild/cloudbuild.yaml
@@ -94,7 +94,7 @@ steps:
     # can start running as soon as the build does.
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     waitFor: [ '-' ]
-    alloFailure: true
+    allowFailure: true
     entrypoint: 'bash'
     args:
       - '-c'

--- a/ci/generate-build-examples.sh
+++ b/ci/generate-build-examples.sh
@@ -212,6 +212,7 @@ cat <<_EOF_
 
   # Remove the images created by this build.
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    allowFailure: true
     entrypoint: 'bash'
     args:
       - '-c'
@@ -220,13 +221,13 @@ cat <<_EOF_
         gcloud container images delete -q gcr.io/\${PROJECT_ID}/ci/run-image:\${BUILD_ID}
         gcloud container images delete -q gcr.io/\${PROJECT_ID}/ci/build-image:\${BUILD_ID}
         gcloud container images delete -q gcr.io/\${PROJECT_ID}/ci/hello-world:\${BUILD_ID}
-        exit 0
 
   # The previous step may not run if the build fails. Garbage collect any
   # images created by this script more than 4 weeks ago. This step should
   # not break the build on error, and it can start running as soon as the
   # build does.
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    allowFailure: true
     waitFor: ['-']
     entrypoint: 'bash'
     args:
@@ -239,5 +240,4 @@ cat <<_EOF_
           xargs printf "gcr.io/\${PROJECT_ID}/\$\${image}@\$\$1\n"
         done | \\
         xargs -P 4 -L 32 gcloud container images delete -q --force-delete-tags
-        exit 0
 _EOF_


### PR DESCRIPTION
Simplify error handling in optional steps for the Google Cloud Build config files.