### PR TITLE
ci: always save vcpkg cache

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,6 +42,13 @@ jobs:
         cmake -S . -B "${{runner.temp}}/build" -GNinja
         -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
         -DCMAKE_TOOLCHAIN_FILE="${{runner.temp}}/vcpkg/scripts/buildsystems/vcpkg.cmake"
+    - uses: actions/cache/save@v3
+      if: always()
+      with:
+        path: |
+          ~/.cache/vcpkg
+          ~/.cache/bin
+        key: vcpkg-${{ env.vcpkg_SHA }}-build-ubuntu-focal-${{ hashFiles('vcpkg.json') }}
     - name: build
       run: cmake --build "${{runner.temp}}/build"
     - name: test
@@ -82,6 +89,12 @@ jobs:
         run: >
           cmake -S examples/site/howto_local_development -B "${{runner.temp}}/howto_local_development/build" -GNinja
           -DCMAKE_TOOLCHAIN_FILE=/usr/local/share/vcpkg/scripts/buildsystems/vcpkg.cmake
+      - uses: actions/cache/save@v3
+        if: always()
+        with:
+          path: |
+            ~/.cache/vcpkg
+          key: vcpkg-${{ env.vcpkg_SHA }}-${{ runner.os }}-${{ hashFiles('vcpkg.json') }}
       - name: build-local-development
         env:
           VCPKG_OVERLAY_PORTS: "${{runner.temp}}/quickstart/vcpkg-overlays"
@@ -127,6 +140,12 @@ jobs:
             '-DBUILD_TESTING=ON' `
             '-DFUNCTIONS_FRAMEWORK_CPP_TEST_EXAMPLES=OFF' `
             '-DCMAKE_TOOLCHAIN_FILE=${{runner.temp}}/vcpkg/scripts/buildsystems/vcpkg.cmake'
+      - uses: actions/cache/save@v3
+        if: always()
+        with:
+          path: |
+            ~\AppData\Local\vcpkg\archives
+          key: vcpkg-${{ env.vcpkg_SHA }}-build-msvc-2019-2-${{ hashFiles('vcpkg.json') }}
       - name: build
         run: cmake --build "${{runner.temp}}/build"
       - name: test
@@ -167,6 +186,13 @@ jobs:
           cmake -S . -B "${{runner.temp}}/build" -GNinja
           -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
           -DCMAKE_TOOLCHAIN_FILE="${{runner.temp}}/vcpkg/scripts/buildsystems/vcpkg.cmake"
+      - uses: actions/cache/save@v3
+        if: always()
+        with:
+          path: |
+            ~/.cache/vcpkg
+            ~/.cache/bin
+          key: vcpkg-${{ env.vcpkg_SHA }}-build-macos-10-${{ hashFiles('vcpkg.json') }}
       - name: build
         run: cmake --build "${{runner.temp}}/build"
       - name: test

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -43,13 +43,13 @@ jobs:
         -DCMAKE_BUILD_TYPE=Debug
         -DCMAKE_CXX_FLAGS=--coverage
         -DCMAKE_TOOLCHAIN_FILE="${{runner.temp}}/vcpkg/scripts/buildsystems/vcpkg.cmake"
-      - uses: actions/cache/save@v3
-        if: always()
-        with:
-          path: |
-            ~/.cache/vcpkg
-            ~/.cache/bin
-          key: vcpkg-${{ env.vcpkg_SHA }}-coverage-${{ hashFiles('vcpkg.json') }}
+    - uses: actions/cache/save@v3
+      if: always()
+      with:
+        path: |
+          ~/.cache/vcpkg
+          ~/.cache/bin
+        key: vcpkg-${{ env.vcpkg_SHA }}-coverage-${{ hashFiles('vcpkg.json') }}
     - name: build
       run: cmake --build ${{runner.workspace}}/build
     - name: test

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -43,6 +43,13 @@ jobs:
         -DCMAKE_BUILD_TYPE=Debug
         -DCMAKE_CXX_FLAGS=--coverage
         -DCMAKE_TOOLCHAIN_FILE="${{runner.temp}}/vcpkg/scripts/buildsystems/vcpkg.cmake"
+      - uses: actions/cache/save@v3
+        if: always()
+        with:
+          path: |
+            ~/.cache/vcpkg
+            ~/.cache/bin
+          key: vcpkg-${{ env.vcpkg_SHA }}-coverage-${{ hashFiles('vcpkg.json') }}
     - name: build
       run: cmake --build ${{runner.workspace}}/build
     - name: test

--- a/.github/workflows/sanitize.yaml
+++ b/.github/workflows/sanitize.yaml
@@ -53,6 +53,13 @@ jobs:
           -DCMAKE_CXX_FLAGS="-fsanitize=${{matrix.sanitizer}} -DGRPC_TSAN_SUPPRESSED -DGRPC_ASAN_SUPPRESSED"
           -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
           -DCMAKE_TOOLCHAIN_FILE="${{runner.temp}}/vcpkg/scripts/buildsystems/vcpkg.cmake"
+      - uses: actions/cache/save@v3
+        if: always()
+        with:
+          path: |
+            ~/.cache/vcpkg
+            ~/.cache/bin
+          key: vcpkg-${{ env.vcpkg_SHA }}-sanitize-${{ matrix.sanitizer }}-${{ hashFiles('vcpkg.json') }}
       - name: -fsanitize=${{matrix.sanitizer}} / build
         run: cmake --build "${{runner.temp}}/build"
       - name: -fsanitize=${{matrix.sanitizer}} / test

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -41,6 +41,13 @@ jobs:
           cmake -S . -B "${{runner.temp}}/build"
           -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
           -DCMAKE_TOOLCHAIN_FILE="${{runner.temp}}/vcpkg/scripts/buildsystems/vcpkg.cmake"
+      - uses: actions/cache/save@v3
+        if: always()
+        with:
+          path: |
+            ~/.cache/vcpkg
+            ~/.cache/bin
+          key: vcpkg-${{ env.vcpkg_SHA }}-style-clang-tidy-${{ hashFiles('vcpkg.json') }}
       - name: tidy
         run: >
           git ls-files -z -- '*.cc' |
@@ -90,6 +97,13 @@ jobs:
           -DCMAKE_BUILD_TYPE=Debug
           -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
           -DCMAKE_TOOLCHAIN_FILE="${{runner.temp}}/vcpkg/scripts/buildsystems/vcpkg.cmake"
+      - uses: actions/cache/save@v3
+        if: always()
+        with:
+          path: |
+            ~/.cache/vcpkg
+            ~/.cache/bin
+          key: vcpkg-${{ env.vcpkg_SHA }}-werror-${{ matrix.compiler.cxx }}-${{ hashFiles('vcpkg.json') }}
       - name: compiler=${{matrix.compiler.cxx}} / build
         run: cmake --build "${{runner.temp}}/build"
       - name: compiler=${{matrix.compiler.cxx}} / test


### PR DESCRIPTION
Save the vcpkg cache immediately after it is generated. This makes the next run faster if there is an error compiling our code or running one of our tests.