### PR TITLE
docs: use working buildpacks

### DIFF
--- a/examples/site/howto_create_container/README.md
+++ b/examples/site/howto_create_container/README.md
@@ -87,7 +87,7 @@ containing your function:
 
 ```shell
 pack build \
-    --builder gcr.io/buildpacks/builder:latest \
+    --builder gcr.io/buildpacks/builder:v1 \
     --env GOOGLE_FUNCTION_TARGET=hello_world_http \
     --path examples/site/hello_world_http \
     gcf-cpp-hello-world-http

--- a/examples/site/howto_deploy_cloud_event/README.md
+++ b/examples/site/howto_deploy_cloud_event/README.md
@@ -90,7 +90,7 @@ containing your function:
 ```shell
 GOOGLE_CLOUD_PROJECT=... # put the right value here
 pack build \
-    --builder gcr.io/buildpacks/builder:latest \
+    --builder gcr.io/buildpacks/builder:v1 \
     --env GOOGLE_FUNCTION_TARGET=hello_world_pubsub \
     --path examples/site/hello_world_pubsub \
    "gcr.io/${GOOGLE_CLOUD_PROJECT}/gcf-cpp-hello-world-pubsub"

--- a/examples/site/howto_deploy_to_cloud_run/README.md
+++ b/examples/site/howto_deploy_to_cloud_run/README.md
@@ -102,7 +102,7 @@ containing your function:
 ```shell
 GOOGLE_CLOUD_PROJECT=... # put the right value here
 pack build \
-    --builder gcr.io/buildpacks/builder:latest \
+    --builder gcr.io/buildpacks/builder:v1 \
     --env GOOGLE_FUNCTION_TARGET=hello_world_http \
     --path examples/site/hello_world_http \
    "gcr.io/${GOOGLE_CLOUD_PROJECT}/gcf-cpp-hello-world-http"

--- a/examples/site/testing_storage/README.md
+++ b/examples/site/testing_storage/README.md
@@ -67,8 +67,7 @@ We will create a container for the storage "hello world" function as usual:
 
 ```shell
 pack build \
-    --builder gcr.io/buildpacks/builder:latest \
-    --env "GOOGLE_FUNCTION_SIGNATURE_TYPE=cloudevent" \
+    --builder gcr.io/buildpacks/builder:v1 \
     --env "GOOGLE_FUNCTION_TARGET=hello_world_storage" \
     --path "examples/site/hello_world_storage" \
     "gcr.io/${GOOGLE_CLOUD_PROJECT}/gcf-hello-world-storage"


### PR DESCRIPTION
The newest buildpacks don't compile the C++ examples. Probably an omission in the buildpack. Change the documents to use the correct version.