### PR TITLE
ci: make `check-api` build functional

### DIFF
--- a/ci/cloudbuild/build.sh
+++ b/ci/cloudbuild/build.sh
@@ -265,6 +265,7 @@ if [[ -n "${CLOUD_FLAG}" ]]; then
     "--region=us-east1"
   )
   io::run gcloud builds submit "${args[@]}" .
+  exit
 fi
 
 # Default to --docker mode since no other mode was specified.

--- a/ci/cloudbuild/cloudbuild.yaml
+++ b/ci/cloudbuild/cloudbuild.yaml
@@ -62,19 +62,16 @@ steps:
   - name: 'gcr.io/${PROJECT_ID}/${_IMAGE}:${BUILD_ID}'
     entrypoint: '/bin/true'
 
-  # Restores the homedir cache into /h in parallel with the previous step.
-  - name: 'gcr.io/cloud-builders/gsutil'
-    waitFor: [ '-' ]
-    allowFailure: true
-    entrypoint: 'bash'
-    dir: '/h'
-    args:
-      - '-c'
-      - >
-        /workspace/ci/cloudbuild/cache.sh restore
-        --bucket_url=gs://${_CACHE_BUCKET}/build-cache/functions-framework-cpp
-        --key=${_TRIGGER_SOURCE}/${_DISTRO}-${_BUILD_NAME}/h
-        --fallback_key=main/${_DISTRO}-${_BUILD_NAME}/h
+  # Runs the specified build in the image that was created in the first step.
+  - name: 'gcr.io/${PROJECT_ID}/${_IMAGE}:${BUILD_ID}'
+    entrypoint: 'ci/cloudbuild/build.sh'
+    args: [ '--local', '--build', '${_BUILD_NAME}' ]
+    env: [
+      'SCCACHE_GCS_BUCKET=${_CACHE_BUCKET}',
+      'SCCACHE_GCS_KEY_PREFIX=sccache/${_DISTRO}-${_BUILD_NAME}',
+      'SCCACHE_GCS_RW_MODE=READ_WRITE',
+      'VCPKG_BINARY_SOURCES=x-gcs,gs://${_CACHE_BUCKET}/vcpkg-cache/${_DISTRO}-${_BUILD_NAME},readwrite'
+    ]
 
   # Remove the images created by this build.
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'

--- a/ci/cloudbuild/dockerfiles/fedora-34.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/fedora-34.Dockerfile
@@ -41,15 +41,16 @@ RUN curl -sSL https://github.com/universal-ctags/ctags/archive/refs/tags/p5.9.20
 # https://github.com/lvc/abi-dumper/pull/29. We can switch back to `dnf install
 # abi-dumper` once it has the fix.
 WORKDIR /var/tmp/build
-RUN curl -sSL https://github.com/lvc/abi-dumper/archive/814effec0f20a9613441dfa033aa0a0bc2a96a87.tar.gz | \
+RUN curl -sSL https://github.com/lvc/abi-dumper/archive/16bb467cd7d343dd3a16782b151b56cf15509594.tar.gz | \
     tar -xzf - --strip-components=1 && \
     mv abi-dumper.pl /usr/local/bin/abi-dumper && \
     chmod +x /usr/local/bin/abi-dumper
 
 WORKDIR /var/tmp/gcloud
-ARG GOOGLE_CLOUD_CPP_CLOUD_SDK_VERSION="348.0.0"
-ARG GOOGLE_CLOUD_CPP_SDK_SHA256="8341a9b21088fd382522be247c7e51c61d8ea4ff86e6ededfa601afd5223e153"
-ENV TARBALL="google-cloud-sdk-${GOOGLE_CLOUD_CPP_CLOUD_SDK_VERSION}-linux-x86_64.tar.gz"
-RUN curl -sSL "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/${TARBALL}" -o "${TARBALL}"
+ARG GOOGLE_CLOUD_CPP_CLOUD_SDK_VERSION="428.0.0"
+ARG GOOGLE_CLOUD_CPP_SDK_SHA256="a665909d2ff9cd3a927d84670c5a8d11f0c5fbcda2540bbea44e0d6f77b82e27"
+ENV TARBALL="google-cloud-cli-${GOOGLE_CLOUD_CPP_CLOUD_SDK_VERSION}-linux-x86_64.tar.gz"
+RUN curl -fsSL "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/${TARBALL}" -o "${TARBALL}"
 RUN echo "${GOOGLE_CLOUD_CPP_SDK_SHA256} ${TARBALL}" | sha256sum --check -
 RUN tar x -C /usr/local -f "${TARBALL}"
+ENV PATH=${PATH}:/usr/local/google-cloud-sdk/bin


### PR DESCRIPTION
The most important step in the build (running the build!) was not configured.  I updated some tools and enabled GCS-based cache for vcpkg.