### PR TITLE
docs: ask customers to follow the released instructions

### DIFF
--- a/examples/howto_use_legacy_code/README.md
+++ b/examples/howto_use_legacy_code/README.md
@@ -14,7 +14,11 @@ any external tool to compile some code. Often this function also downloads
 the code from some external repository, but it can use code in your source
 tree.
 
-[ExternalProject_Add]: https://cmake.org/cmake/help/latest/module/ExternalProject.html
+> **WARNING:** the development version of this document may not work with the
+> released version of the functions framework. Please use this document as it
+> appears in the [corresponding release][github-releases] if you are using a
+> released version of the library. In particular, buildpacks use the latest
+> release.
 
 ## Installing Dependencies
 
@@ -146,3 +150,5 @@ You can just interrupt (`Ctrl-C`) the program to terminate it.
 [vcpkg-install]: https://github.com/microsoft/vcpkg#getting-started
 [cmake]: https://cmake.org
 [cmake-install]: https://cmake.org/install/
+[ExternalProject_Add]: https://cmake.org/cmake/help/latest/module/ExternalProject.html
+[github-releases]: https://github.com/GoogleCloudPlatform/functions-framework-cpp/releases

--- a/examples/howto_use_legacy_code/README.md
+++ b/examples/howto_use_legacy_code/README.md
@@ -14,7 +14,7 @@ any external tool to compile some code. Often this function also downloads
 the code from some external repository, but it can use code in your source
 tree.
 
-> **WARNING:** the development version of this document may not work with the
+> **WARNING:** The development version of this document may not work with the
 > released version of the functions framework. Please use this document as it
 > appears in the [corresponding release][github-releases] if you are using a
 > released version of the library. In particular, buildpacks use the latest

--- a/examples/site/howto_create_container/README.md
+++ b/examples/site/howto_create_container/README.md
@@ -3,6 +3,12 @@
 This guide shows you how to create a container image for an example function,
 and how to run said image in a local container on your workstation.
 
+> **WARNING:** the development version of this document may not work with the
+> released version of the functions framework. Please use this document as it
+> appears in the [corresponding release][github-releases] if you are using a
+> released version of the library. In particular, buildpacks use the latest
+> release.
+
 ## Pre-requisites
 
 Verify the [docker tool][docker] is functional on your workstation:
@@ -132,3 +138,4 @@ docker image rm gcf-cpp-hello-world-http
 [sudoless docker]: https://docs.docker.com/engine/install/linux-postinstall/
 [pack-install]: https://buildpacks.io/docs/install-pack/
 [Google Cloud buildpack]: https://github.com/GoogleCloudPlatform/buildpacks
+[github-releases]: https://github.com/GoogleCloudPlatform/functions-framework-cpp/releases

--- a/examples/site/howto_create_container/README.md
+++ b/examples/site/howto_create_container/README.md
@@ -3,7 +3,7 @@
 This guide shows you how to create a container image for an example function,
 and how to run said image in a local container on your workstation.
 
-> **WARNING:** the development version of this document may not work with the
+> **WARNING:** The development version of this document may not work with the
 > released version of the functions framework. Please use this document as it
 > appears in the [corresponding release][github-releases] if you are using a
 > released version of the library. In particular, buildpacks use the latest

--- a/examples/site/howto_deploy_cloud_event/README.md
+++ b/examples/site/howto_deploy_cloud_event/README.md
@@ -1,5 +1,14 @@
 # How-to Guide: Deploy a C++ Pub/Sub function to Cloud Run
 
+This guide shows how to deploy a C++ function consuming cloud events to
+[Cloud Run].
+
+> **WARNING:** the development version of this document may not work with the
+> released version of the functions framework. Please use this document as it
+> appears in the [corresponding release][github-releases] if you are using a
+> released version of the library. In particular, buildpacks use the latest
+> release.
+
 ## Pre-requisites
 
 This guide assumes you are familiar with Google Cloud, and that you have a GCP
@@ -215,3 +224,5 @@ gcloud container images delete \
 [pack-install]: https://buildpacks.io/docs/install-pack/
 [gcloud-eventarc-create]: https://cloud.google.com/sdk/gcloud/reference/beta/eventarc/triggers/create
 [Google Cloud buildpack]: https://github.com/GoogleCloudPlatform/buildpacks
+[Cloud Run]: https://cloud.google.com/run
+[github-releases]: https://github.com/GoogleCloudPlatform/functions-framework-cpp/releases

--- a/examples/site/howto_deploy_cloud_event/README.md
+++ b/examples/site/howto_deploy_cloud_event/README.md
@@ -3,7 +3,7 @@
 This guide shows how to deploy a C++ function consuming cloud events to
 [Cloud Run].
 
-> **WARNING:** the development version of this document may not work with the
+> **WARNING:** The development version of this document may not work with the
 > released version of the functions framework. Please use this document as it
 > appears in the [corresponding release][github-releases] if you are using a
 > released version of the library. In particular, buildpacks use the latest

--- a/examples/site/howto_deploy_to_cloud_run/README.md
+++ b/examples/site/howto_deploy_to_cloud_run/README.md
@@ -3,7 +3,7 @@
 This guide shows how to deploy a C++ function handling HTTP requests to
 [Cloud Run].
 
-> **WARNING:** the development version of this document may not work with the
+> **WARNING:** The development version of this document may not work with the
 > released version of the functions framework. Please use this document as it
 > appears in the [corresponding release][github-releases] if you are using a
 > released version of the library. In particular, buildpacks use the latest
@@ -171,4 +171,5 @@ gcloud container images delete \
 [docker-install]: https://store.docker.com/search?type=edition&offering=community
 [sudoless docker]: https://docs.docker.com/engine/install/linux-postinstall/
 [pack-install]: https://buildpacks.io/docs/install-pack/
+[Cloud Run]: https://cloud.google.com/run
 [github-releases]: https://github.com/GoogleCloudPlatform/functions-framework-cpp/releases

--- a/examples/site/howto_deploy_to_cloud_run/README.md
+++ b/examples/site/howto_deploy_to_cloud_run/README.md
@@ -1,14 +1,13 @@
 # How-to Guide: Deploy your function to Cloud Run
 
-[repository-gh]: https://github.com/GoogleCloudPlatform/functions-framework-cpp
-[howto-create-container]: /examples/site/howto_create_container/README.md
-[cloud-run-quickstarts]: https://cloud.google.com/run/docs/quickstarts
-[gcp-quickstarts]: https://cloud.google.com/resource-manager/docs/creating-managing-projects
-[buildpacks]: https://buildpacks.io
-[docker]: https://docker.com/
-[docker-install]: https://store.docker.com/search?type=edition&offering=community
-[sudoless docker]: https://docs.docker.com/engine/install/linux-postinstall/
-[pack-install]: https://buildpacks.io/docs/install-pack/
+This guide shows how to deploy a C++ function handling HTTP requests to
+[Cloud Run].
+
+> **WARNING:** the development version of this document may not work with the
+> released version of the functions framework. Please use this document as it
+> appears in the [corresponding release][github-releases] if you are using a
+> released version of the library. In particular, buildpacks use the latest
+> release.
 
 ## Pre-requisites
 
@@ -162,3 +161,14 @@ And the container image:
 gcloud container images delete \
     "gcr.io/${GOOGLE_CLOUD_PROJECT}/gcf-cpp-hello-world-http:latest"
 ```
+
+[repository-gh]: https://github.com/GoogleCloudPlatform/functions-framework-cpp
+[howto-create-container]: /examples/site/howto_create_container/README.md
+[cloud-run-quickstarts]: https://cloud.google.com/run/docs/quickstarts
+[gcp-quickstarts]: https://cloud.google.com/resource-manager/docs/creating-managing-projects
+[buildpacks]: https://buildpacks.io
+[docker]: https://docker.com/
+[docker-install]: https://store.docker.com/search?type=edition&offering=community
+[sudoless docker]: https://docs.docker.com/engine/install/linux-postinstall/
+[pack-install]: https://buildpacks.io/docs/install-pack/
+[github-releases]: https://github.com/GoogleCloudPlatform/functions-framework-cpp/releases

--- a/examples/site/howto_local_development/README.md
+++ b/examples/site/howto_local_development/README.md
@@ -4,7 +4,7 @@ This guide describes how to compile and run a function locally. This can be
 useful when writing unit test, or to accelerate the edit -> compile -> test
 cycle.
 
-> **WARNING:** the development version of this document may not work with the
+> **WARNING:** The development version of this document may not work with the
 > released version of the functions framework. Please use this document as it
 > appears in the [corresponding release][github-releases] if you are using a
 > released version of the library. In particular, buildpacks use the latest

--- a/examples/site/howto_local_development/README.md
+++ b/examples/site/howto_local_development/README.md
@@ -4,6 +4,12 @@ This guide describes how to compile and run a function locally. This can be
 useful when writing unit test, or to accelerate the edit -> compile -> test
 cycle.
 
+> **WARNING:** the development version of this document may not work with the
+> released version of the functions framework. Please use this document as it
+> appears in the [corresponding release][github-releases] if you are using a
+> released version of the library. In particular, buildpacks use the latest
+> release.
+
 ## Installing Dependencies
 
 Because the Functions Framework for C++ uses C++17, you will need a working C++
@@ -134,3 +140,4 @@ You can just interrupt (`Ctrl-C`) the program to terminate it.
 [vcpkg-install]: https://github.com/microsoft/vcpkg#getting-started
 [cmake]: https://cmake.org
 [cmake-install]: https://cmake.org/install/
+[github-releases]: https://github.com/GoogleCloudPlatform/functions-framework-cpp/releases


### PR DESCRIPTION
From time-to-time we need to update the instructions in the development branch to match the next release. That may invalidate the instructions if they are used with older releases. Put a warning in the "How-to" guides to avoid the problem.