### PR TITLE
cleanup: take advantage of CMake >= 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,10 +34,6 @@ project(
     DESCRIPTION "Functions Framework for C++"
     LANGUAGES CXX)
 
-# Configure the compiler options, we will be using C++17 features.
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
 if (VCPKG_TARGET_TRIPLET MATCHES "-static$")

--- a/google/cloud/functions/CMakeLists.txt
+++ b/google/cloud/functions/CMakeLists.txt
@@ -78,6 +78,7 @@ target_include_directories(functions_framework_cpp
                            PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>)
 target_include_directories(functions_framework_cpp SYSTEM
                            PUBLIC $<INSTALL_INTERFACE:include>)
+target_compile_features(functions_framework_cpp PUBLIC cxx_std_17)
 target_link_libraries(
     functions_framework_cpp PUBLIC absl::time Boost::headers
                                    Boost::program_options Threads::Threads)


### PR DESCRIPTION
With CMake >= 3.10 we can require C++ >= 17 using
`target_compile_features()`. These have the advantage of propagating to downstream dependencies, that is, everything that links the library also requires C++ >= 17.