### PR TITLE
cleanup: fix GCC warnings with Wall

### DIFF
--- a/examples/site/http_content/http_content.cc
+++ b/examples/site/http_content/http_content.cc
@@ -66,7 +66,7 @@ std::string urldecode(std::string const& encoded) {
       auto const* end = encoded.data() + i + 3;
       auto r =
           std::from_chars(encoded.data() + i + 1, end, value, kUrlEncodingBase);
-      if (r.ptr == end) {
+      if (r.ec == std::errc{} && r.ptr == end) {
         result.push_back(value);
         i += 2;
       } else {

--- a/google/cloud/functions/CMakeLists.txt
+++ b/google/cloud/functions/CMakeLists.txt
@@ -123,6 +123,16 @@ if (BUILD_TESTING)
         functions_framework_cpp_add_common_options(${target})
         add_test(NAME ${target} COMMAND ${target})
     endforeach ()
+    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+        # GCC turns on -Wmaybe-unitialized with -Wall. This results in false
+        # positives in this test, but the warning was useful in other tests.
+        # For examples of the false positives see:
+        #     https://godbolt.org/z/xhj57Y6qG
+        # more information at:
+        #     https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80635
+        target_compile_options(
+            cloud_event_test PRIVATE "-Wno-maybe-uninitialized")
+    endif ()
 
     add_subdirectory(integration_tests)
 endif ()


### PR DESCRIPTION
I was too optimistic about the state of the code with GCC 13, while the code is clean with Clang, there was a useful warning emited by GCC 13, and a number of useless warnings too.