### PR TITLE
fix: add `nlohmann_json` as required CMake target

### DIFF
--- a/google/cloud/functions/CMakeLists.txt
+++ b/google/cloud/functions/CMakeLists.txt
@@ -23,6 +23,7 @@ configure_file(internal/version_info.h.in
 find_package(absl REQUIRED)
 find_package(Boost REQUIRED COMPONENTS program_options)
 find_package(Threads REQUIRED)
+find_package(nlohmann_json REQUIRED)
 
 add_library(
     functions_framework_cpp # cmake-format: sort
@@ -80,7 +81,8 @@ target_include_directories(functions_framework_cpp SYSTEM
                            PUBLIC $<INSTALL_INTERFACE:include>)
 target_link_libraries(
     functions_framework_cpp PUBLIC absl::time Boost::headers
-                                   Boost::program_options Threads::Threads)
+                                   Boost::program_options Threads::Threads
+                                   nlohmann_json::nlohmann_json)
 if ("${Boost_VERSION_STRING}" VERSION_LESS "1.81")
     target_compile_definitions(functions_framework_cpp
                                PUBLIC BOOST_BEAST_USE_STD_STRING_VIEW)

--- a/google/cloud/functions/CMakeLists.txt
+++ b/google/cloud/functions/CMakeLists.txt
@@ -80,10 +80,10 @@ target_include_directories(functions_framework_cpp
 target_include_directories(functions_framework_cpp SYSTEM
                            PUBLIC $<INSTALL_INTERFACE:include>)
 target_link_libraries(
-    functions_framework_cpp PUBLIC absl::time Boost::headers
     functions_framework_cpp
     PUBLIC absl::time Boost::headers Boost::program_options Threads::Threads
-           nlohmann_json::nlohmann_json)
+    PRIVATE nlohmann_json::nlohmann_json)
+
 if ("${Boost_VERSION_STRING}" VERSION_LESS "1.81")
     target_compile_definitions(functions_framework_cpp
                                PUBLIC BOOST_BEAST_USE_STD_STRING_VIEW)

--- a/google/cloud/functions/CMakeLists.txt
+++ b/google/cloud/functions/CMakeLists.txt
@@ -81,8 +81,9 @@ target_include_directories(functions_framework_cpp SYSTEM
                            PUBLIC $<INSTALL_INTERFACE:include>)
 target_link_libraries(
     functions_framework_cpp PUBLIC absl::time Boost::headers
-                                   Boost::program_options Threads::Threads
-                                   nlohmann_json::nlohmann_json)
+    functions_framework_cpp
+    PUBLIC absl::time Boost::headers Boost::program_options Threads::Threads
+           nlohmann_json::nlohmann_json)
 if ("${Boost_VERSION_STRING}" VERSION_LESS "1.81")
     target_compile_definitions(functions_framework_cpp
                                PUBLIC BOOST_BEAST_USE_STD_STRING_VIEW)

--- a/google/cloud/functions/config.cmake.in
+++ b/google/cloud/functions/config.cmake.in
@@ -16,6 +16,7 @@ include(CMakeFindDependencyMacro)
 find_dependency(absl)
 find_dependency(Boost COMPONENTS program_options)
 find_dependency(Threads)
+find_dependency(nlohmann_json)
 
 set(FUNCTIONS_FRAMEWORK_CPP_VERSION @PROJECT_VERSION@)
 


### PR DESCRIPTION
The project nlohmann_json is used in few files, but is not listed in CMakeLists.txt. It would be nice having it listed in the CMake file too.

Reference about nlogmann_json CMake target: https://json.nlohmann.me/integration/cmake/

Files using nlogmann_json:

- https://github.com/GoogleCloudPlatform/functions-framework-cpp/blob/main/google/cloud/functions/internal/parse_cloud_event_legacy.cc
- https://github.com/GoogleCloudPlatform/functions-framework-cpp/blob/main/google/cloud/functions/internal/parse_cloud_event_storage.cc

/cc @toge
