### PR TITLE
ci: pass codecov token

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -79,5 +79,7 @@ jobs:
 
     - name: coverage-upload
       working-directory: ${{runner.workspace}}
+      env:
+        CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}
       run: >
         /bin/bash <(curl -s https://codecov.io/bash) -X coveragepy -x /usr/bin/gcov


### PR DESCRIPTION
Recently codecov.io started requiring an explicit token.